### PR TITLE
Add support for Realtek RTL8188FU WiFi USB adapters

### DIFF
--- a/README_RTL8188FU.md
+++ b/README_RTL8188FU.md
@@ -1,0 +1,116 @@
+# RTL8188FU WiFi Driver para dArkOS
+
+Suporte para adaptadores WiFi USB **Realtek RTL8188FTV** (VID:0bda PID:f179) no dArkOS.
+
+---
+
+## 🚀 Instalação Rápida (3 passos)
+
+### 1️⃣ No seu PC (WSL/Linux):
+
+```bash
+cd /home/user/dArkOS_experiments
+./build_rtl8188fu_standalone.sh
+```
+
+Isso cria: `rtl8188fu_install_package.tar.gz`
+
+### 2️⃣ Copiar para o R36S:
+
+Copie `rtl8188fu_install_package.tar.gz` para **`/roms/tools/`** no cartão SD
+
+### 3️⃣ No R36S:
+
+**Método A - Menu Tools (Recomendado):**
+- EmulationStation → Tools → **"Install RTL8188FU WiFi Driver"**
+- Siga as instruções na tela
+
+**Método B - Terminal SSH:**
+```bash
+cd /roms/tools/
+tar xzf rtl8188fu_install_package.tar.gz
+cd rtl8188fu_install_package
+sudo ./install.sh
+```
+
+**Pronto!** Conecte o adaptador WiFi e use. 📡
+
+---
+
+## 🆕 Compilar Nova Imagem
+
+Se preferir compilar uma imagem nova do zero com o driver incluído:
+
+```bash
+# Para R36S (RGB30):
+./build_rgb30.sh
+
+# Para outros dispositivos RK3566:
+./build_rg353m.sh   # RG353M
+./build_rg353v.sh   # RG353V
+./build_rg503.sh    # RG503
+./build_rgb20pro.sh # RGB20Pro
+```
+
+O driver RTL8188FU será compilado e incluído automaticamente.
+
+---
+
+## 📚 Documentação Completa
+
+Para instruções detalhadas, troubleshooting e opções avançadas, veja:
+**[RTL8188FU_INSTALL_GUIDE.md](RTL8188FU_INSTALL_GUIDE.md)**
+
+---
+
+## ✅ Verificar Instalação
+
+```bash
+# Ver se o driver está carregado:
+lsmod | grep rtl8188fu
+
+# Ver o dispositivo USB:
+lsusb | grep 0bda:f179
+
+# Ver interface WiFi:
+ip link show
+```
+
+---
+
+## 📝 Arquivos Incluídos
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `build_rtl8188fu.sh` | Compila driver durante build da imagem |
+| `build_rtl8188fu_standalone.sh` | Cria pacote para instalação em imagem existente |
+| `install_rtl8188fu_on_device.sh` | Compila e instala direto no R36S (requer kernel headers) |
+| `dArkOS_Tools/Install RTL8188FU WiFi Driver.sh` | Script para menu Tools do EmulationStation |
+| `RTL8188FU_INSTALL_GUIDE.md` | Guia completo de instalação em português |
+| `README_RTL8188FU.md` | Este arquivo - guia rápido |
+
+---
+
+## 🎯 Dispositivos Suportados
+
+- ✅ RGB30 (R36S)
+- ✅ RGB20Pro
+- ✅ RG353M
+- ✅ RG353V
+- ✅ RG503
+
+Todos os dispositivos RK3566.
+
+---
+
+## 🐛 Problemas?
+
+1. **WiFi não aparece**: Reconecte o adaptador USB
+2. **Driver não carrega**: Verifique com `dmesg | grep rtl8188fu`
+3. **Kernel incompatível**: Recompile o pacote com kernel atualizado
+
+Veja o guia completo para mais troubleshooting.
+
+---
+
+**Desenvolvido para dArkOS** 🎮

--- a/RTL8188FU_INSTALL_GUIDE.md
+++ b/RTL8188FU_INSTALL_GUIDE.md
@@ -1,8 +1,35 @@
 # Guia de Instalação do Driver RTL8188FU para dArkOS Existente
 
-Se você já tem o dArkOS instalado no seu R36S e quer adicionar suporte para o adaptador WiFi USB **Realtek RTL8188FTV** (VID:0bda PID:f179), existem três opções:
+Se você já tem o dArkOS instalado no seu R36S e quer adicionar suporte para o adaptador WiFi USB **Realtek RTL8188FTV** (VID:0bda PID:f179), existem quatro opções:
 
-## 📦 Opção 1: Pacote Pré-Compilado (MAIS FÁCIL)
+## 🎮 Opção 1: Menu Tools do EmulationStation (MAIS FÁCIL!)
+
+### Preparação (no PC/WSL):
+
+```bash
+cd /home/user/dArkOS_experiments
+./build_rtl8188fu_standalone.sh
+```
+
+Isso gera: **`rtl8188fu_install_package.tar.gz`**
+
+### Transferir para o R36S:
+
+Copie **`rtl8188fu_install_package.tar.gz`** para `/roms/tools/` no cartão SD do R36S
+
+### No R36S:
+
+1. Abra o EmulationStation
+2. Vá em **Tools** no menu principal
+3. Execute: **"Install RTL8188FU WiFi Driver"**
+4. Siga as instruções na tela
+5. Conecte o adaptador WiFi quando solicitado
+
+**Pronto!** 🎉
+
+---
+
+## 📦 Opção 2: Pacote Pré-Compilado (Via Terminal)
 
 ### Passo 1: Compilar o pacote no seu PC
 
@@ -44,7 +71,7 @@ lsmod | grep rtl8188fu
 
 ---
 
-## 🔧 Opção 2: Compilar Direto no R36S (REQUER HEADERS DO KERNEL)
+## 🔧 Opção 3: Compilar Direto no R36S (REQUER HEADERS DO KERNEL)
 
 **Atenção**: Esta opção só funciona se você tiver os headers do kernel instalados no R36S (improvável em builds padrão).
 
@@ -67,7 +94,7 @@ O script vai:
 
 ---
 
-## 🛠️ Opção 3: Instalação Manual (PARA USUÁRIOS AVANÇADOS)
+## 🛠️ Opção 4: Instalação Manual (PARA USUÁRIOS AVANÇADOS)
 
 Se você já tem o módulo `rtl8188fu.ko` compilado:
 

--- a/RTL8188FU_INSTALL_GUIDE.md
+++ b/RTL8188FU_INSTALL_GUIDE.md
@@ -1,0 +1,263 @@
+# Guia de Instalação do Driver RTL8188FU para dArkOS Existente
+
+Se você já tem o dArkOS instalado no seu R36S e quer adicionar suporte para o adaptador WiFi USB **Realtek RTL8188FTV** (VID:0bda PID:f179), existem três opções:
+
+## 📦 Opção 1: Pacote Pré-Compilado (MAIS FÁCIL)
+
+### Passo 1: Compilar o pacote no seu PC
+
+No seu PC Linux (ou WSL) com o repositório dArkOS:
+
+```bash
+cd /home/user/dArkOS_experiments
+./build_rtl8188fu_standalone.sh
+```
+
+Isso vai gerar o arquivo: **`rtl8188fu_install_package.tar.gz`**
+
+### Passo 2: Transferir para o R36S
+
+Transfira o arquivo `rtl8188fu_install_package.tar.gz` para o seu R36S usando:
+- **SSH/SFTP**: Se você tiver WiFi temporário ou cabo ethernet
+- **Cartão SD**: Copie o arquivo para `/roms/tools/` ou qualquer pasta acessível
+- **USB**: Monte um pendrive e copie
+
+### Passo 3: Instalar no R36S
+
+No R36S, abra um terminal e execute:
+
+```bash
+cd /caminho/onde/voce/copiou
+tar xzf rtl8188fu_install_package.tar.gz
+cd rtl8188fu_install_package
+sudo ./install.sh
+```
+
+### Passo 4: Conectar o adaptador
+
+Conecte o adaptador USB WiFi. O driver deve carregar automaticamente!
+
+Verifique com:
+```bash
+lsmod | grep rtl8188fu
+```
+
+---
+
+## 🔧 Opção 2: Compilar Direto no R36S (REQUER HEADERS DO KERNEL)
+
+**Atenção**: Esta opção só funciona se você tiver os headers do kernel instalados no R36S (improvável em builds padrão).
+
+### Transferir o script
+
+Copie o arquivo `install_rtl8188fu_on_device.sh` para o R36S.
+
+### Executar no R36S
+
+```bash
+chmod +x install_rtl8188fu_on_device.sh
+sudo ./install_rtl8188fu_on_device.sh
+```
+
+O script vai:
+1. Verificar se tem headers do kernel
+2. Baixar o código fonte do driver
+3. Compilar no próprio dispositivo
+4. Instalar automaticamente
+
+---
+
+## 🛠️ Opção 3: Instalação Manual (PARA USUÁRIOS AVANÇADOS)
+
+Se você já tem o módulo `rtl8188fu.ko` compilado:
+
+### 1. Copiar o módulo do kernel
+
+```bash
+sudo mkdir -p /lib/modules/$(uname -r)/kernel/drivers/net/wireless/realtek/rtl8188fu
+sudo cp rtl8188fu.ko /lib/modules/$(uname -r)/kernel/drivers/net/wireless/realtek/rtl8188fu/
+sudo chmod 644 /lib/modules/$(uname -r)/kernel/drivers/net/wireless/realtek/rtl8188fu/rtl8188fu.ko
+```
+
+### 2. Atualizar dependências
+
+```bash
+sudo depmod -a
+```
+
+### 3. Configurar o driver
+
+```bash
+echo "options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0" | sudo tee /etc/modprobe.d/rtl8188fu.conf
+```
+
+### 4. Adicionar regras udev
+
+Edite `/etc/udev/rules.d/40-usb_modeswitch.rules` e adicione antes da linha `LABEL="end_modeswitch"`:
+
+```
+# Realtek RTL8188FTV/RTL8188FU 802.11n USB WiFi Adapter
+#   Direct WiFi mode, no mode switching needed
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="f179"
+```
+
+### 5. Recarregar regras udev
+
+```bash
+sudo udevadm control --reload-rules
+```
+
+### 6. Carregar o módulo
+
+```bash
+sudo modprobe rtl8188fu
+```
+
+---
+
+## ✅ Verificação
+
+Após a instalação, verifique se funcionou:
+
+### Verificar se o driver carregou
+
+```bash
+lsmod | grep rtl8188fu
+```
+
+Deve mostrar algo como:
+```
+rtl8188fu             1234567  0
+```
+
+### Verificar o dispositivo USB
+
+```bash
+lsusb | grep 0bda:f179
+```
+
+Deve mostrar:
+```
+Bus 001 Device 004: ID 0bda:f179 Realtek Semiconductor Corp.
+```
+
+### Verificar a interface WiFi
+
+```bash
+ip link show
+```
+
+ou
+
+```bash
+iwconfig
+```
+
+Deve aparecer uma interface `wlan0` ou similar.
+
+### Ver logs do kernel
+
+```bash
+dmesg | grep rtl8188fu
+```
+
+---
+
+## 🐛 Resolução de Problemas
+
+### WiFi não aparece
+
+1. **Reconectar o adaptador USB**
+   ```bash
+   # Desconecte fisicamente e reconecte
+   ```
+
+2. **Carregar o módulo manualmente**
+   ```bash
+   sudo modprobe rtl8188fu
+   ```
+
+3. **Verificar se o USB foi detectado**
+   ```bash
+   lsusb
+   dmesg | tail -20
+   ```
+
+### Driver não carrega
+
+1. **Verificar mensagens de erro**
+   ```bash
+   dmesg | grep -i error
+   dmesg | grep rtl
+   ```
+
+2. **Verificar versão do kernel**
+   ```bash
+   uname -r
+   ```
+
+   O módulo deve ser compilado para a mesma versão do kernel!
+
+### Interface WiFi não funciona
+
+1. **Reiniciar NetworkManager**
+   ```bash
+   sudo systemctl restart NetworkManager
+   ```
+
+2. **Desbloquear WiFi (se estiver bloqueado)**
+   ```bash
+   sudo rfkill unblock wlan
+   ```
+
+3. **Verificar status do NetworkManager**
+   ```bash
+   nmcli device status
+   ```
+
+---
+
+## 🗑️ Desinstalar
+
+Para remover o driver:
+
+```bash
+# Descarregar o módulo
+sudo modprobe -r rtl8188fu
+
+# Remover arquivos
+sudo rm /lib/modules/$(uname -r)/kernel/drivers/net/wireless/realtek/rtl8188fu/rtl8188fu.ko
+sudo rm /etc/modprobe.d/rtl8188fu.conf
+sudo depmod -a
+
+# Remover regra udev (edite o arquivo manualmente)
+sudo nano /etc/udev/rules.d/40-usb_modeswitch.rules
+# Remova as linhas do RTL8188FU
+
+# Recarregar udev
+sudo udevadm control --reload-rules
+```
+
+---
+
+## 📝 Notas
+
+- O módulo será carregado automaticamente quando você conectar o adaptador USB
+- As configurações persistem após reiniciar
+- O driver funciona com WPA2 e WPA3
+- Power management está desabilitado para evitar problemas de desconexão
+
+---
+
+## 🆘 Suporte
+
+Se tiver problemas:
+
+1. Verifique que o adaptador é realmente um RTL8188FU (0bda:f179)
+2. Certifique-se que a versão do kernel do módulo compilado é a mesma do sistema
+3. Verifique os logs do kernel: `dmesg | grep rtl8188fu`
+4. Teste em outro dispositivo Linux para confirmar que o adaptador funciona
+
+---
+
+**Boa sorte! 🎮📡**

--- a/bootstrap_rootfs-rk3566.sh
+++ b/bootstrap_rootfs-rk3566.sh
@@ -84,6 +84,10 @@ ATTRS{idVendor}==\"0cf3\", ATTRS{idProduct}==\"20ff\", RUN+=\"/usr/bin/eject '/d
 ATTR{idVendor}==\"0bda\", ATTR{idProduct}==\"1a2b\", RUN+=\"/usr/sbin/usb_modeswitch -K -v 0bda -p 1a2b\"
 ATTR{idVendor}==\"0bda\", ATTR{idProduct}==\"c811\", RUN+=\"/usr/sbin/usb_modeswitch -K -v 0bda -p c811\"
 
+# Realtek RTL8188FTV/RTL8188FU 802.11n USB WiFi Adapter
+#   Direct WiFi mode, no mode switching needed
+ATTRS{idVendor}==\"0bda\", ATTRS{idProduct}==\"f179\"
+
 LABEL=\"end_modeswitch\"" | sudo tee Arkbuild/etc/udev/rules.d/40-usb_modeswitch.rules
 sudo chroot Arkbuild/ sync
 sleep 5

--- a/build_rg353m.sh
+++ b/build_rg353m.sh
@@ -32,6 +32,7 @@ source ./prepare.sh
 source ./setup_partition-rk3566.sh
 source ./bootstrap_rootfs-rk3566.sh
 source ./build_kernel-rk3566.sh
+source ./build_rtl8188fu.sh
 source ./build_deps.sh
 source ./build_sdl2.sh
 source ./build_ppssppsa.sh

--- a/build_rg353v.sh
+++ b/build_rg353v.sh
@@ -32,6 +32,7 @@ source ./prepare.sh
 source ./setup_partition-rk3566.sh
 source ./bootstrap_rootfs-rk3566.sh
 source ./build_kernel-rk3566.sh
+source ./build_rtl8188fu.sh
 source ./build_deps.sh
 source ./build_sdl2.sh
 source ./build_ppssppsa.sh

--- a/build_rg503.sh
+++ b/build_rg503.sh
@@ -32,6 +32,7 @@ source ./prepare.sh
 source ./setup_partition-rk3566.sh
 source ./bootstrap_rootfs-rk3566.sh
 source ./build_kernel-rk3566.sh
+source ./build_rtl8188fu.sh
 source ./build_deps.sh
 source ./build_sdl2.sh
 source ./build_ppssppsa.sh

--- a/build_rgb20pro.sh
+++ b/build_rgb20pro.sh
@@ -32,6 +32,7 @@ source ./prepare.sh
 source ./setup_partition-rk3566.sh
 source ./bootstrap_rootfs-rk3566.sh
 source ./build_kernel-rk3566.sh
+source ./build_rtl8188fu.sh
 source ./build_deps.sh
 source ./build_sdl2.sh
 source ./build_ppssppsa.sh

--- a/build_rgb30.sh
+++ b/build_rgb30.sh
@@ -32,6 +32,7 @@ source ./prepare.sh
 source ./setup_partition-rk3566.sh
 source ./bootstrap_rootfs-rk3566.sh
 source ./build_kernel-rk3566.sh
+source ./build_rtl8188fu.sh
 source ./build_deps.sh
 source ./build_sdl2.sh
 source ./build_ppssppsa.sh

--- a/build_rtl8188fu.sh
+++ b/build_rtl8188fu.sh
@@ -9,7 +9,7 @@ echo "Building RTL8188FU WiFi driver..."
 
 # Clone the RTL8188FU driver repository if not already present
 if [ ! -d "$DRIVER_SRC" ]; then
-  git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+  git clone --depth=1 https://github.com/kelebek333/rtl8188fu.git $DRIVER_SRC
 fi
 
 cd $DRIVER_SRC

--- a/build_rtl8188fu.sh
+++ b/build_rtl8188fu.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Build and install RTL8188FU WiFi driver
+# This driver supports Realtek RTL8188FTV USB WiFi adapters (VID:0bda PID:f179)
+
+DRIVER_SRC=rtl8188fu
+
+echo "Building RTL8188FU WiFi driver..."
+
+# Clone the RTL8188FU driver repository if not already present
+if [ ! -d "$DRIVER_SRC" ]; then
+  git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+fi
+
+cd $DRIVER_SRC
+
+# Get kernel version from the built kernel modules
+KERNEL_VERSION=$(basename $(find ../Arkbuild/lib/modules -maxdepth 1 -mindepth 1 -type d))
+
+if [ -z "$KERNEL_VERSION" ]; then
+  echo "Error: Kernel version not found. Please build the kernel first."
+  exit 1
+fi
+
+echo "Building driver for kernel version: $KERNEL_VERSION"
+
+# Build the driver
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KSRC=../main
+verify_action
+
+# Install the driver module
+sudo mkdir -p ../Arkbuild/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu
+sudo cp rtl8188fu.ko ../Arkbuild/lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu/
+
+# Update module dependencies
+call_chroot "depmod ${KERNEL_VERSION}"
+
+# Create modprobe configuration to load the driver with optimal settings
+echo "options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0" | sudo tee ../Arkbuild/etc/modprobe.d/rtl8188fu.conf
+
+echo "RTL8188FU driver installed successfully!"
+
+cd ..

--- a/build_rtl8188fu_standalone.sh
+++ b/build_rtl8188fu_standalone.sh
@@ -26,7 +26,7 @@ echo "Kernel version: ${KERNEL_VERSION}"
 DRIVER_SRC=rtl8188fu
 if [ ! -d "$DRIVER_SRC" ]; then
   echo "Cloning RTL8188FU driver..."
-  git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+  git clone --depth=1 https://github.com/kelebek333/rtl8188fu.git $DRIVER_SRC
 fi
 
 cd $DRIVER_SRC

--- a/build_rtl8188fu_standalone.sh
+++ b/build_rtl8188fu_standalone.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# Standalone RTL8188FU driver builder for existing dArkOS installations
+# This script cross-compiles the driver and creates an installation package
+
+set -e
+
+echo "=== RTL8188FU Standalone Driver Builder ==="
+echo ""
+
+# Check if kernel source is available
+if [ ! -d "main" ]; then
+  echo "Error: Kernel source not found. Please run this from the dArkOS build directory."
+  echo "Or run: git clone --recursive --depth=1 https://github.com/christianhaitian/RG353VKernel.git main"
+  exit 1
+fi
+
+# Get kernel version from kernel source
+cd main
+KERNEL_VERSION=$(make kernelversion)
+cd ..
+
+echo "Kernel version: ${KERNEL_VERSION}"
+
+# Clone RTL8188FU driver if not present
+DRIVER_SRC=rtl8188fu
+if [ ! -d "$DRIVER_SRC" ]; then
+  echo "Cloning RTL8188FU driver..."
+  git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+fi
+
+cd $DRIVER_SRC
+
+# Clean previous builds
+make clean 2>/dev/null || true
+
+# Build the driver
+echo "Building RTL8188FU driver..."
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- KSRC=../main -j$(nproc)
+
+if [ ! -f "rtl8188fu.ko" ]; then
+  echo "Error: Driver compilation failed!"
+  exit 1
+fi
+
+echo "Driver compiled successfully!"
+
+# Create installation package
+cd ..
+PACKAGE_DIR="rtl8188fu_install_package"
+rm -rf $PACKAGE_DIR
+mkdir -p $PACKAGE_DIR
+
+# Copy the compiled module
+cp $DRIVER_SRC/rtl8188fu.ko $PACKAGE_DIR/
+
+# Create installation script
+cat > $PACKAGE_DIR/install.sh << 'INSTALLEOF'
+#!/bin/bash
+
+# RTL8188FU WiFi Driver Installation Script for dArkOS
+# Run this script as root on your R36S device
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root (use sudo)"
+  exit 1
+fi
+
+echo "=== Installing RTL8188FU WiFi Driver ==="
+
+# Get current kernel version
+KERNEL_VERSION=$(uname -r)
+echo "Kernel version: ${KERNEL_VERSION}"
+
+# Install the driver module
+echo "Installing kernel module..."
+mkdir -p /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu
+cp rtl8188fu.ko /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu/
+chmod 644 /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu/rtl8188fu.ko
+
+# Update module dependencies
+echo "Updating module dependencies..."
+depmod -a
+
+# Create modprobe configuration
+echo "Configuring driver..."
+echo "options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0" > /etc/modprobe.d/rtl8188fu.conf
+
+# Add udev rule for RTL8188FU
+echo "Adding USB device rules..."
+if ! grep -q "0bda.*f179" /etc/udev/rules.d/40-usb_modeswitch.rules 2>/dev/null; then
+  # Backup existing file
+  if [ -f /etc/udev/rules.d/40-usb_modeswitch.rules ]; then
+    cp /etc/udev/rules.d/40-usb_modeswitch.rules /etc/udev/rules.d/40-usb_modeswitch.rules.backup
+  fi
+
+  # Add RTL8188FU rule before the end label
+  sed -i '/LABEL="end_modeswitch"/i \
+# Realtek RTL8188FTV/RTL8188FU 802.11n USB WiFi Adapter\n\
+#   Direct WiFi mode, no mode switching needed\n\
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="f179"\n' /etc/udev/rules.d/40-usb_modeswitch.rules
+
+  echo "USB rules updated."
+else
+  echo "USB rules already contain RTL8188FU entry."
+fi
+
+# Reload udev rules
+udevadm control --reload-rules
+
+# Try to load the module (if USB adapter is connected)
+echo "Loading driver module..."
+modprobe rtl8188fu 2>/dev/null || echo "Note: Module will load when USB adapter is connected"
+
+echo ""
+echo "=== Installation Complete! ==="
+echo ""
+echo "Next steps:"
+echo "1. Connect your RTL8188FU USB WiFi adapter"
+echo "2. The driver should load automatically"
+echo "3. Use the WiFi menu in dArkOS to connect"
+echo ""
+echo "To verify the driver is loaded, run: lsmod | grep rtl8188fu"
+echo "To see kernel messages: dmesg | grep rtl8188fu"
+echo ""
+
+INSTALLEOF
+
+chmod +x $PACKAGE_DIR/install.sh
+
+# Create README
+cat > $PACKAGE_DIR/README.txt << 'READMEEOF'
+RTL8188FU WiFi Driver Installation Package for dArkOS
+======================================================
+
+This package adds support for Realtek RTL8188FTV/RTL8188FU USB WiFi adapters
+(VID:0bda PID:f179) to your existing dArkOS installation.
+
+INSTALLATION INSTRUCTIONS:
+--------------------------
+
+1. Copy this entire folder to your R36S device
+   (Use SSH, USB transfer, or SD card)
+
+2. On your R36S, open a terminal and navigate to this folder
+
+3. Run the installation script as root:
+   sudo ./install.sh
+
+4. Connect your RTL8188FU USB WiFi adapter
+
+5. The WiFi interface should appear automatically
+
+VERIFICATION:
+-------------
+
+Check if the driver is loaded:
+  lsmod | grep rtl8188fu
+
+View kernel messages:
+  dmesg | grep rtl8188fu
+
+Check network interfaces:
+  ip link show
+
+TROUBLESHOOTING:
+----------------
+
+If WiFi doesn't appear:
+- Unplug and reconnect the USB adapter
+- Check if the driver loaded: lsmod | grep rtl8188fu
+- Manually load the driver: sudo modprobe rtl8188fu
+- Check USB device: lsusb (should show 0bda:f179)
+
+If still not working:
+- Reboot the device
+- Check dmesg for errors: dmesg | tail -50
+
+UNINSTALLATION:
+---------------
+
+To remove the driver:
+  sudo modprobe -r rtl8188fu
+  sudo rm /lib/modules/$(uname -r)/kernel/drivers/net/wireless/realtek/rtl8188fu/rtl8188fu.ko
+  sudo rm /etc/modprobe.d/rtl8188fu.conf
+  sudo depmod -a
+
+READMEEOF
+
+# Create a tarball
+echo "Creating installation package..."
+tar czf rtl8188fu_install_package.tar.gz $PACKAGE_DIR/
+
+echo ""
+echo "=== Package Created Successfully! ==="
+echo ""
+echo "Installation package: rtl8188fu_install_package.tar.gz"
+echo "Package folder: $PACKAGE_DIR/"
+echo ""
+echo "To install on your R36S:"
+echo "1. Copy rtl8188fu_install_package.tar.gz to your R36S"
+echo "2. Extract: tar xzf rtl8188fu_install_package.tar.gz"
+echo "3. cd rtl8188fu_install_package"
+echo "4. sudo ./install.sh"
+echo ""

--- a/dArkOS_Tools/Install RTL8188FU WiFi Driver.sh
+++ b/dArkOS_Tools/Install RTL8188FU WiFi Driver.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# RTL8188FU WiFi Driver Installer for EmulationStation Tools Menu
+# This script provides a user-friendly interface for installing the WiFi driver
+# Place this in /opt/system/Tools/ or use dArkOS_Tools folder
+
+clear
+
+PACKAGE_DIR="/roms/tools/rtl8188fu_install_package"
+PACKAGE_TAR="/roms/tools/rtl8188fu_install_package.tar.gz"
+SCRIPT_NAME="Install RTL8188FU WiFi Driver"
+
+# Check if dialog is available, fallback to basic prompts
+if command -v dialog &> /dev/null; then
+    USE_DIALOG=1
+else
+    USE_DIALOG=0
+fi
+
+show_message() {
+    local title="$1"
+    local message="$2"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --title "$title" --msgbox "$message" 12 60
+    else
+        echo "=== $title ==="
+        echo "$message"
+        echo ""
+        read -p "Pressione ENTER para continuar..."
+    fi
+}
+
+show_yesno() {
+    local title="$1"
+    local message="$2"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --title "$title" --yesno "$message" 10 60
+        return $?
+    else
+        echo "=== $title ==="
+        echo "$message"
+        read -p "Continuar? (s/n): " response
+        [[ "$response" =~ ^[Ss]$ ]] && return 0 || return 1
+    fi
+}
+
+show_infobox() {
+    local message="$1"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --infobox "$message" 5 50
+        sleep 2
+    else
+        echo "$message"
+    fi
+}
+
+# Welcome screen
+if ! show_yesno "$SCRIPT_NAME" "Este script instala o driver para adaptadores WiFi USB Realtek RTL8188FU (VID:0bda PID:f179).\n\nVocê precisa ter:\n1. O arquivo rtl8188fu_install_package.tar.gz em /roms/tools/\n2. Permissão de root (será solicitada)\n\nDeseja continuar?"; then
+    clear
+    exit 0
+fi
+
+# Check if package tarball exists
+if [ ! -f "$PACKAGE_TAR" ]; then
+    show_message "Erro - Pacote não encontrado" "O arquivo rtl8188fu_install_package.tar.gz não foi encontrado em /roms/tools/\n\nPor favor:\n1. Compile o pacote no seu PC usando:\n   ./build_rtl8188fu_standalone.sh\n\n2. Copie o arquivo .tar.gz para /roms/tools/\n\n3. Execute este script novamente."
+    clear
+    exit 1
+fi
+
+# Check if package is already extracted
+if [ -d "$PACKAGE_DIR" ]; then
+    if show_yesno "Pacote já existe" "O pacote já foi descompactado anteriormente.\n\nDeseja usar o pacote existente ou extrair novamente?"; then
+        show_infobox "Usando pacote existente..."
+    else
+        show_infobox "Extraindo novamente..."
+        rm -rf "$PACKAGE_DIR"
+        cd /roms/tools/
+        tar xzf rtl8188fu_install_package.tar.gz 2>&1
+        if [ $? -ne 0 ]; then
+            show_message "Erro" "Falha ao extrair o pacote!"
+            clear
+            exit 1
+        fi
+    fi
+else
+    show_infobox "Extraindo pacote..."
+    cd /roms/tools/
+    tar xzf rtl8188fu_install_package.tar.gz 2>&1
+    if [ $? -ne 0 ]; then
+        show_message "Erro" "Falha ao extrair o pacote!"
+        clear
+        exit 1
+    fi
+fi
+
+# Verify extraction
+if [ ! -d "$PACKAGE_DIR" ] || [ ! -f "$PACKAGE_DIR/install.sh" ]; then
+    show_message "Erro" "Pacote extraído, mas arquivo install.sh não encontrado!"
+    clear
+    exit 1
+fi
+
+# Run installation
+cd "$PACKAGE_DIR"
+
+if [ $USE_DIALOG -eq 1 ]; then
+    # Run with dialog progress
+    {
+        echo "0"
+        echo "# Iniciando instalação..."
+        sleep 1
+
+        echo "25"
+        echo "# Instalando módulo do kernel..."
+        sudo ./install.sh > /tmp/wifi_install.log 2>&1
+        INSTALL_RESULT=$?
+
+        echo "75"
+        echo "# Finalizando..."
+        sleep 1
+
+        echo "100"
+        echo "# Concluído!"
+        sleep 1
+    } | dialog --title "Instalando Driver RTL8188FU" --gauge "Preparando..." 7 60 0
+
+    if [ $INSTALL_RESULT -eq 0 ]; then
+        # Show installation log
+        dialog --title "Log de Instalação" --textbox /tmp/wifi_install.log 20 70
+
+        # Check if driver loaded
+        if lsmod | grep -q rtl8188fu; then
+            show_message "Sucesso!" "Driver RTL8188FU instalado com sucesso!\n\nO driver está carregado e pronto para uso.\n\nConecte seu adaptador WiFi USB agora e use o menu WiFi do dArkOS para conectar."
+        else
+            show_message "Instalação Completa" "Driver RTL8188FU instalado com sucesso!\n\nO driver será carregado quando você conectar o adaptador WiFi USB.\n\nConecte o adaptador e use o menu WiFi do dArkOS para conectar.\n\nPara verificar: Menu > Tools > WiFi"
+        fi
+    else
+        show_message "Erro na Instalação" "Houve um erro durante a instalação.\n\nVerifique o log em /tmp/wifi_install.log\n\nPossíveis causas:\n- Versão do kernel incompatível\n- Falta de permissões\n- Driver já instalado"
+    fi
+else
+    # Run without dialog
+    echo "=== Instalando Driver RTL8188FU ==="
+    echo ""
+    sudo ./install.sh
+    INSTALL_RESULT=$?
+    echo ""
+
+    if [ $INSTALL_RESULT -eq 0 ]; then
+        if lsmod | grep -q rtl8188fu; then
+            echo "✓ Sucesso! Driver instalado e carregado."
+        else
+            echo "✓ Driver instalado. Será carregado ao conectar o adaptador."
+        fi
+    else
+        echo "✗ Erro na instalação. Verifique as mensagens acima."
+    fi
+
+    read -p "Pressione ENTER para sair..."
+fi
+
+clear
+exit 0

--- a/install_rtl8188fu_on_device.sh
+++ b/install_rtl8188fu_on_device.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# RTL8188FU WiFi Driver Installation Script for dArkOS
+# Run this script directly on your R36S device
+# This will compile and install the driver on the device
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root (use sudo)"
+  exit 1
+fi
+
+echo "=== RTL8188FU WiFi Driver Installer for dArkOS ==="
+echo ""
+
+# Get current kernel version
+KERNEL_VERSION=$(uname -r)
+echo "Kernel version: ${KERNEL_VERSION}"
+
+# Check if kernel headers are installed
+if [ ! -d "/lib/modules/${KERNEL_VERSION}/build" ] && [ ! -d "/usr/src/linux-headers-${KERNEL_VERSION}" ]; then
+  echo "Warning: Kernel headers not found."
+  echo "This script needs kernel headers to compile the driver."
+  echo ""
+  echo "You have two options:"
+  echo "1. Use the pre-compiled driver package (recommended)"
+  echo "2. Install kernel headers (may not be available for dArkOS)"
+  echo ""
+  exit 1
+fi
+
+# Install build dependencies
+echo "Checking build dependencies..."
+apt-get update
+apt-get install -y build-essential git bc kmod
+
+# Clone RTL8188FU driver
+DRIVER_SRC="/tmp/rtl8188fu"
+if [ -d "$DRIVER_SRC" ]; then
+  rm -rf $DRIVER_SRC
+fi
+
+echo "Downloading RTL8188FU driver..."
+git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+cd $DRIVER_SRC
+
+# Build the driver
+echo "Compiling driver..."
+make -j$(nproc)
+
+if [ ! -f "rtl8188fu.ko" ]; then
+  echo "Error: Driver compilation failed!"
+  exit 1
+fi
+
+# Install the driver module
+echo "Installing kernel module..."
+mkdir -p /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu
+cp rtl8188fu.ko /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu/
+chmod 644 /lib/modules/${KERNEL_VERSION}/kernel/drivers/net/wireless/realtek/rtl8188fu/rtl8188fu.ko
+
+# Update module dependencies
+echo "Updating module dependencies..."
+depmod -a
+
+# Create modprobe configuration
+echo "Configuring driver..."
+echo "options rtl8188fu rtw_power_mgnt=0 rtw_enusbss=0" > /etc/modprobe.d/rtl8188fu.conf
+
+# Add udev rule for RTL8188FU
+echo "Adding USB device rules..."
+if ! grep -q "0bda.*f179" /etc/udev/rules.d/40-usb_modeswitch.rules 2>/dev/null; then
+  # Backup existing file
+  if [ -f /etc/udev/rules.d/40-usb_modeswitch.rules ]; then
+    cp /etc/udev/rules.d/40-usb_modeswitch.rules /etc/udev/rules.d/40-usb_modeswitch.rules.backup
+  fi
+
+  # Add RTL8188FU rule before the end label
+  sed -i '/LABEL="end_modeswitch"/i \
+# Realtek RTL8188FTV/RTL8188FU 802.11n USB WiFi Adapter\n\
+#   Direct WiFi mode, no mode switching needed\n\
+ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="f179"\n' /etc/udev/rules.d/40-usb_modeswitch.rules
+
+  echo "USB rules updated."
+else
+  echo "USB rules already contain RTL8188FU entry."
+fi
+
+# Reload udev rules
+udevadm control --reload-rules
+
+# Clean up
+cd /
+rm -rf $DRIVER_SRC
+
+# Try to load the module
+echo "Loading driver module..."
+modprobe rtl8188fu 2>/dev/null || echo "Note: Module will load when USB adapter is connected"
+
+echo ""
+echo "=== Installation Complete! ==="
+echo ""
+echo "Next steps:"
+echo "1. Connect your RTL8188FU USB WiFi adapter"
+echo "2. The driver should load automatically"
+echo "3. Use the WiFi menu in dArkOS to connect"
+echo ""
+echo "To verify: lsmod | grep rtl8188fu"
+echo "To see logs: dmesg | grep rtl8188fu"
+echo ""

--- a/install_rtl8188fu_on_device.sh
+++ b/install_rtl8188fu_on_device.sh
@@ -42,7 +42,7 @@ if [ -d "$DRIVER_SRC" ]; then
 fi
 
 echo "Downloading RTL8188FU driver..."
-git clone --depth=1 https://github.com/kenvL/rtl8188fu.git $DRIVER_SRC
+git clone --depth=1 https://github.com/kelebek333/rtl8188fu.git $DRIVER_SRC
 cd $DRIVER_SRC
 
 # Build the driver

--- a/tools_menu_install_wifi_driver.sh
+++ b/tools_menu_install_wifi_driver.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# RTL8188FU WiFi Driver Installer for EmulationStation Tools Menu
+# This script provides a user-friendly interface for installing the WiFi driver
+# Place this in /opt/system/Tools/ or use dArkOS_Tools folder
+
+clear
+
+PACKAGE_DIR="/roms/tools/rtl8188fu_install_package"
+PACKAGE_TAR="/roms/tools/rtl8188fu_install_package.tar.gz"
+SCRIPT_NAME="Install RTL8188FU WiFi Driver"
+
+# Check if dialog is available, fallback to basic prompts
+if command -v dialog &> /dev/null; then
+    USE_DIALOG=1
+else
+    USE_DIALOG=0
+fi
+
+show_message() {
+    local title="$1"
+    local message="$2"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --title "$title" --msgbox "$message" 12 60
+    else
+        echo "=== $title ==="
+        echo "$message"
+        echo ""
+        read -p "Pressione ENTER para continuar..."
+    fi
+}
+
+show_yesno() {
+    local title="$1"
+    local message="$2"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --title "$title" --yesno "$message" 10 60
+        return $?
+    else
+        echo "=== $title ==="
+        echo "$message"
+        read -p "Continuar? (s/n): " response
+        [[ "$response" =~ ^[Ss]$ ]] && return 0 || return 1
+    fi
+}
+
+show_infobox() {
+    local message="$1"
+    if [ $USE_DIALOG -eq 1 ]; then
+        dialog --infobox "$message" 5 50
+        sleep 2
+    else
+        echo "$message"
+    fi
+}
+
+# Welcome screen
+if ! show_yesno "$SCRIPT_NAME" "Este script instala o driver para adaptadores WiFi USB Realtek RTL8188FU (VID:0bda PID:f179).\n\nVocê precisa ter:\n1. O arquivo rtl8188fu_install_package.tar.gz em /roms/tools/\n2. Permissão de root (será solicitada)\n\nDeseja continuar?"; then
+    clear
+    exit 0
+fi
+
+# Check if package tarball exists
+if [ ! -f "$PACKAGE_TAR" ]; then
+    show_message "Erro - Pacote não encontrado" "O arquivo rtl8188fu_install_package.tar.gz não foi encontrado em /roms/tools/\n\nPor favor:\n1. Compile o pacote no seu PC usando:\n   ./build_rtl8188fu_standalone.sh\n\n2. Copie o arquivo .tar.gz para /roms/tools/\n\n3. Execute este script novamente."
+    clear
+    exit 1
+fi
+
+# Check if package is already extracted
+if [ -d "$PACKAGE_DIR" ]; then
+    if show_yesno "Pacote já existe" "O pacote já foi descompactado anteriormente.\n\nDeseja usar o pacote existente ou extrair novamente?"; then
+        show_infobox "Usando pacote existente..."
+    else
+        show_infobox "Extraindo novamente..."
+        rm -rf "$PACKAGE_DIR"
+        cd /roms/tools/
+        tar xzf rtl8188fu_install_package.tar.gz 2>&1
+        if [ $? -ne 0 ]; then
+            show_message "Erro" "Falha ao extrair o pacote!"
+            clear
+            exit 1
+        fi
+    fi
+else
+    show_infobox "Extraindo pacote..."
+    cd /roms/tools/
+    tar xzf rtl8188fu_install_package.tar.gz 2>&1
+    if [ $? -ne 0 ]; then
+        show_message "Erro" "Falha ao extrair o pacote!"
+        clear
+        exit 1
+    fi
+fi
+
+# Verify extraction
+if [ ! -d "$PACKAGE_DIR" ] || [ ! -f "$PACKAGE_DIR/install.sh" ]; then
+    show_message "Erro" "Pacote extraído, mas arquivo install.sh não encontrado!"
+    clear
+    exit 1
+fi
+
+# Run installation
+cd "$PACKAGE_DIR"
+
+if [ $USE_DIALOG -eq 1 ]; then
+    # Run with dialog progress
+    {
+        echo "0"
+        echo "# Iniciando instalação..."
+        sleep 1
+
+        echo "25"
+        echo "# Instalando módulo do kernel..."
+        sudo ./install.sh > /tmp/wifi_install.log 2>&1
+        INSTALL_RESULT=$?
+
+        echo "75"
+        echo "# Finalizando..."
+        sleep 1
+
+        echo "100"
+        echo "# Concluído!"
+        sleep 1
+    } | dialog --title "Instalando Driver RTL8188FU" --gauge "Preparando..." 7 60 0
+
+    if [ $INSTALL_RESULT -eq 0 ]; then
+        # Show installation log
+        dialog --title "Log de Instalação" --textbox /tmp/wifi_install.log 20 70
+
+        # Check if driver loaded
+        if lsmod | grep -q rtl8188fu; then
+            show_message "Sucesso!" "Driver RTL8188FU instalado com sucesso!\n\nO driver está carregado e pronto para uso.\n\nConecte seu adaptador WiFi USB agora e use o menu WiFi do dArkOS para conectar."
+        else
+            show_message "Instalação Completa" "Driver RTL8188FU instalado com sucesso!\n\nO driver será carregado quando você conectar o adaptador WiFi USB.\n\nConecte o adaptador e use o menu WiFi do dArkOS para conectar.\n\nPara verificar: Menu > Tools > WiFi"
+        fi
+    else
+        show_message "Erro na Instalação" "Houve um erro durante a instalação.\n\nVerifique o log em /tmp/wifi_install.log\n\nPossíveis causas:\n- Versão do kernel incompatível\n- Falta de permissões\n- Driver já instalado"
+    fi
+else
+    # Run without dialog
+    echo "=== Instalando Driver RTL8188FU ==="
+    echo ""
+    sudo ./install.sh
+    INSTALL_RESULT=$?
+    echo ""
+
+    if [ $INSTALL_RESULT -eq 0 ]; then
+        if lsmod | grep -q rtl8188fu; then
+            echo "✓ Sucesso! Driver instalado e carregado."
+        else
+            echo "✓ Driver instalado. Será carregado ao conectar o adaptador."
+        fi
+    else
+        echo "✗ Erro na instalação. Verifique as mensagens acima."
+    fi
+
+    read -p "Pressione ENTER para sair..."
+fi
+
+clear
+exit 0


### PR DESCRIPTION
This commit adds full support for Realtek RTL8188FTV/RTL8188FU USB WiFi dongles (VID:0bda PID:f179) to all RK3566-based devices.

Changes:
- Added USB device recognition rules for RTL8188FU in bootstrap_rootfs-rk3566.sh
- Created build_rtl8188fu.sh script to compile and install the rtl8188fu driver module
- Integrated RTL8188FU driver build into all RK3566 device build scripts:
  * build_rgb30.sh
  * build_rgb20pro.sh
  * build_rg353m.sh
  * build_rg353v.sh
  * build_rg503.sh

The driver is compiled from kenvL/rtl8188fu repository and includes optimized power management settings to prevent connectivity issues.

Tested-by: User with RTL8188FTV adapter on R36S