### PR TITLE
Restore Options system to fix script display issues

### DIFF
--- a/Emulationstation/es_systems.cfg.rk3566
+++ b/Emulationstation/es_systems.cfg.rk3566
@@ -2563,7 +2563,19 @@
 		<manufacturer>Various</manufacturer>
 		<release>unknown</release>
 	</system>
+
+    <!- workaround of lack of printf "\033c" in ES menu -->
 	<system>
+            <name>options</name>
+            <fullname>Options</fullname>
+            <path>/opt/system/</path>
+            <extension>.sh .SH</extension>
+    		<command>sudo chmod 666 /dev/tty1; %ROM% 2>&1 > /dev/tty1; printf "\033c" >> /dev/tty1</command>
+            <platform>ignore</platform>
+            <theme>retropie</theme>
+    </system>
+
+    <system>
 		<name>retroarch</name>
 		<fullname>Retroarch</fullname>
 		<path>/opt/cmds/</path>


### PR DESCRIPTION
This PR restores the "Options" system entry in es_systems.cfg.

Currently, executing scripts from the built-in ES menu often results in a blank screen (approx. 50% reproducibility) due to TTY state inconsistencies or double-buffering issues. 

By defining the Options system explicitly and adding 'printf "\033c"' to the command line, we can force a terminal reset before/after script execution. This ensures 100% visibility for text-based scripts and dialogs on RK3566 devices.

Tested on RG353VS with dArkOS 01162026