### PR TITLE
Suppress time-based error messages in setup script

### DIFF
--- a/scripts/expandtoexfat.sh.rk3326
+++ b/scripts/expandtoexfat.sh.rk3326
@@ -61,7 +61,7 @@ fi
 	echo $exitcode > /tmp/code.txt
 	sleep 2
 	#sudo tar -xf /roms.tar -C / &> /dev/null
-	(pv -n /roms.tar | tar --no-same-permissions --no-same-owner -xf - -C /) &> /tmp/tar_stat.txt &
+	(pv -n /roms.tar | tar --no-same-permissions --no-same-owner --warning=no-timestamp -xf - -C /) &> /tmp/tar_stat.txt &
 	let COUNT=1
 	while true; do
 	  VAL=$(tail -n 1 /tmp/tar_stat.txt)
@@ -86,7 +86,7 @@ fi
 	sync
 	sudo rm -rf /roms/themes/es-theme-nes-box/ &> /dev/null
 	cd /tempthemes
-	(tar --no-same-permissions --no-same-owner -cf - . | pv -n -s $(du -sb /tempthemes/ | awk '{print $1}') | tar --no-same-permissions --no-same-owner -xf - -C /roms/themes/) &> /tmp/tar_stat.txt &
+	(tar --no-same-permissions --no-same-owner --warning=no-timestamp -cf - . | pv -n -s $(du -sb /tempthemes/ | awk '{print $1}') | tar --no-same-permissions --no-same-owner -xf - -C /roms/themes/) &> /tmp/tar_stat.txt &
 	let COUNT=1
 	while true; do
 	  VAL=$(tail -n 1 /tmp/tar_stat.txt)

--- a/scripts/expandtoexfat.sh.rk3566
+++ b/scripts/expandtoexfat.sh.rk3566
@@ -73,7 +73,7 @@ fi
 	sudo mount -t exfat -w /dev/${primary_block}p5 /roms &> /dev/null
 	sleep 2
 	#sudo tar -xf /roms.tar -C / &> /dev/null
-	(pv -n /roms.tar | tar --no-same-permissions --no-same-owner -xf - -C /) &> /tmp/tar_stat.txt &
+	(pv -n /roms.tar | tar --no-same-permissions --no-same-owner --warning=no-timestamp -xf - -C /) &> /tmp/tar_stat.txt &
 	let COUNT=1
 	while true; do
 	  VAL=$(tail -n 1 /tmp/tar_stat.txt)
@@ -102,7 +102,7 @@ fi
 	  sudo rm -rf /tempthemes/es-theme-epic-cody*/ &> /dev/null
 	fi
 	cd /tempthemes
-	(tar --no-same-permissions --no-same-owner -cf - . | pv -n -s $(du -sb /tempthemes/ | awk '{print $1}') | tar --no-same-permissions --no-same-owner -xf - -C /roms/themes/) &> /tmp/tar_stat.txt &
+	(tar --no-same-permissions --no-same-owner --warning=no-timestamp -cf - . | pv -n -s $(du -sb /tempthemes/ | awk '{print $1}') | tar --no-same-permissions --no-same-owner -xf - -C /roms/themes/) &> /tmp/tar_stat.txt &
 	let COUNT=1
 	while true; do
 	  VAL=$(tail -n 1 /tmp/tar_stat.txt)


### PR DESCRIPTION
The console we're installing to may have an incorrect clock at the time of install, which if it is the case, will be very far in the past compared to the timestamps of the OS contents. This could lead to the the `expandtoexfat.sh` script becoming bottlenecked by the framebuffer if it has to write a very large volume of logs noting that roms.tar's timestamps are from a point in time ahead of what the console's clock is set to.  We can append a flag to disable timestamp warnings to the tar call in the `expandtoexfat.sh` scripts to reduce unnecessary log writing to the display and to `/tmp/tar_stat.txt`.