### PR TITLE
gcc-linaro permissions

### DIFF
--- a/build_kernel-rk3566.sh
+++ b/build_kernel-rk3566.sh
@@ -114,7 +114,11 @@ fi
 git clone --depth=1 https://github.com/christianhaitian/rk356x-uboot.git
 git clone https://github.com/christianhaitian/rkbin.git
 mkdir -p ./prebuilts/gcc/linux-x86/aarch64/
-ln -s /opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu ./prebuilts/gcc/linux-x86/aarch64/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
+OPT_TOOLCHAIN_DIR="/opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+LOCAL_TOOLCHAIN_DIR="./prebuilts/gcc/linux-x86/aarch64/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+if [[ -d "$OPT_TOOLCHAIN_DIR" && ! -d "$LOCAL_TOOLCHAIN_DIR" ]]; then
+    ln -s "$OPT_TOOLCHAIN_DIR" "$LOCAL_TOOLCHAIN_DIR"
+fi
 cd rk356x-uboot
 cp ../resource.img rk3566_tool/Image/
 ./make.sh rk3566

--- a/utils.sh
+++ b/utils.sh
@@ -7,10 +7,18 @@ BUILD_DATE=$(date "+%m%d%Y")
 git config --global http.postBuffer 524288000
 
 # Verify the correct toolchain is available
-if [ ! -d "/opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu" ]; then
-  sudo mkdir -p /opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
-  git clone --depth=1 https://github.com/christianhaitian/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu.git /opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
+OPT_TOOLCHAIN_DIR="/opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+LOCAL_TOOLCHAIN_DIR="prebuilts/gcc/linux-x86/aarch64/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+
+if [ -d "$OPT_TOOLCHAIN_DIR" ]; then
+  echo "Using existing system-wide toolchain at $OPT_TOOLCHAIN_DIR"
+elif [ ! -d "$LOCAL_TOOLCHAIN_DIR" ]; then
+  echo "Toolchain not found. Downloading Linaro toolchain to local prebuilts directory..."
+  mkdir -p "$LOCAL_TOOLCHAIN_DIR"
+  git clone --depth=1 https://github.com/christianhaitian/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu.git "$LOCAL_TOOLCHAIN_DIR"
   verify_action
+else
+  echo "Using existing local toolchain at $LOCAL_TOOLCHAIN_DIR"
 fi
 
 # Verify package cache directory exists
@@ -21,7 +29,11 @@ fi
 # Setup the necessary exports
 export ARCH=arm64
 export CROSS_COMPILE=aarch64-linux-gnu-
-export PATH=/opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/:$PATH
+if [ -d "$OPT_TOOLCHAIN_DIR" ]; then
+    export PATH="$OPT_TOOLCHAIN_DIR"/bin/:$PATH
+else
+    export PATH="$LOCAL_TOOLCHAIN_DIR"/bin/:$PATH
+fi
 if [ "$CHIPSET" == "rk3326" ]; then
   export whichmali=libmali-bifrost-g31-rxp0-gbm.so
 else


### PR DESCRIPTION
If gcc-linaro is not already available in /opt/toolchains/, clone to ./prebuilts rather than /opt/toolchains/. This fixes the situation where /opt/toolchains/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/ was created by and owned by root, but git clone was being run as the user and did not have permissions to write to that directory.