### PR TITLE
Add environment variables to Makefile necessary for the build to run smoothly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,21 @@ BUILD_KODI ?= n
 BUILD_ARMHF ?= y
 BUILD_BLUEALSA ?= n
 
+# Ensure system binaries like parted are in the path, and silence strict GCC warnings
+PATH := $(PATH):/usr/sbin:/sbin
+KCFLAGS := -w
+
 export DEBIAN_CODE_NAME
 export ENABLE_CACHE
 export BUILD_KODI
 export BUILD_ARMHF
 export BUILD_BLUEALSA
+export PATH
+export KCFLAGS
 
 ifeq ($(DEBIAN_CODE_NAME),)
   $(error DEBIAN_CODE_NAME is not set. Please run with DEBIAN_CODE_NAME=suite (e.g., trixie))
 endif
-
 
 all:
 	@echo "Please specify a valid build target: make rgb10 or make rg353m"


### PR DESCRIPTION
On Debian and (I think) Ubuntu `/sbin/` and `/usr/sbin/` are not in a normal user's `$PATH`. This results in the following errors:

```
./image_setup.sh: line 9: parted: command not found
./image_setup.sh: line 10: parted: command not found
```

Adding the `sbin` directories to the user's `$PATH` fixes those errors.

The Rockchip and Realtek kernel sources are configured to treat warnings as errors, causing the builds to fail when trying to build dArkOS. Adding `KCFLAGS := -w` removes the strict treatment of warnings.