### PR TITLE
Fix btrfs free-space-tree handling across btrfs-progs versions

### DIFF
--- a/setup_partition-rk3566.sh
+++ b/setup_partition-rk3566.sh
@@ -3,10 +3,16 @@
 
 ROOT_FILESYSTEM_FORMAT="btrfs"
 if [ "$ROOT_FILESYSTEM_FORMAT" == "xfs" ] || [ "$ROOT_FILESYSTEM_FORMAT" == "btrfs" ]; then
-  ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
   if [ "$ROOT_FILESYSTEM_FORMAT" != "btrfs" ]; then
+    ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime"
   else
+    # Only disable free-space-tree if it is supported by mkfs.btrfs
+    if sudo mkfs.btrfs -O list-all 2>&1 | grep -q "free-space-tree"; then
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-O ^free-space-tree -f -L ROOTFS"
+    else
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
+    fi
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime,compress=zstd"
   fi
 elif [[ "$ROOT_FILESYSTEM_FORMAT" == *"ext"* ]]; then

--- a/setup_partition-rk3566.sh
+++ b/setup_partition-rk3566.sh
@@ -7,13 +7,17 @@ if [ "$ROOT_FILESYSTEM_FORMAT" == "xfs" ] || [ "$ROOT_FILESYSTEM_FORMAT" == "btr
     ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime"
   else
-    # Only disable free-space-tree if it is supported by mkfs.btrfs
+    # Disable free-space-tree
+    # In some btrfs-progs versions, this is listed as a filesystem feature (-O)
     if sudo mkfs.btrfs -O list-all 2>&1 | grep -q "free-space-tree"; then
       ROOT_FILESYSTEM_FORMAT_PARAMETERS="-O ^free-space-tree -f -L ROOTFS"
+    # In some btrfs-progs versions, this is listed as a runtime features (-R)
+    elif sudo mkfs.btrfs -R list-all 2>&1 | grep -q "free-space-tree"; then
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-R ^free-space-tree -f -L ROOTFS"
     else
       ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     fi
-    ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime,compress=zstd"
+    ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime,compress=zlib:1"
   fi
 elif [[ "$ROOT_FILESYSTEM_FORMAT" == *"ext"* ]]; then
   ROOT_FILESYSTEM_FORMAT_PARAMETERS="-F -L ROOTFS"

--- a/setup_partition.sh
+++ b/setup_partition.sh
@@ -8,9 +8,13 @@ if [ "$ROOT_FILESYSTEM_FORMAT" == "xfs" ] || [ "$ROOT_FILESYSTEM_FORMAT" == "btr
     ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime"
   else
-    # Only disable free-space-tree if it is supported by mkfs.btrfs
+    # Disable free-space-tree
+    # In some btrfs-progs versions, this is listed as a filesystem feature (-O)
     if sudo mkfs.btrfs -O list-all 2>&1 | grep -q "free-space-tree"; then
       ROOT_FILESYSTEM_FORMAT_PARAMETERS="-O ^free-space-tree -f -L ROOTFS"
+    # In some btrfs-progs versions, this is listed as a runtime features (-R)
+    elif sudo mkfs.btrfs -R list-all 2>&1 | grep -q "free-space-tree"; then
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-R ^free-space-tree -f -L ROOTFS"
     else
       ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     fi

--- a/setup_partition.sh
+++ b/setup_partition.sh
@@ -8,7 +8,12 @@ if [ "$ROOT_FILESYSTEM_FORMAT" == "xfs" ] || [ "$ROOT_FILESYSTEM_FORMAT" == "btr
     ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime"
   else
-    ROOT_FILESYSTEM_FORMAT_PARAMETERS="-O ^free-space-tree -f -L ROOTFS"
+    # Only disable free-space-tree if it is supported by mkfs.btrfs
+    if sudo mkfs.btrfs -O list-all 2>&1 | grep -q "free-space-tree"; then
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-O ^free-space-tree -f -L ROOTFS"
+    else
+      ROOT_FILESYSTEM_FORMAT_PARAMETERS="-f -L ROOTFS"
+    fi
     ROOT_FILESYSTEM_MOUNT_OPTIONS="defaults,noatime,compress=zlib:1"
   fi
 elif [[ "$ROOT_FILESYSTEM_FORMAT" == *"ext"* ]]; then


### PR DESCRIPTION
## Problem                                                                                                                                                                                                     

`setup_partition.sh` unconditionally passes `-O ^free-space-tree` when formatting btrfs partitions. This causes build failures on systems where `mkfs.btrfs` doesn't list `free-space-tree` as a filesystem feature (`-O`).                                                                                                                                                                                                  
  
On my Debian bookworm machine, `free-space-tree` is listed as a runtime feature (`-R list-all`) rather than a filesystem feature (`-O list-all`). The original code only checked `-O`, causing `mkfs.btrfs` to fail with an unrecognized feature error.                                                                                                                                                                         

## Solution                                                                                                                                                                                                    

Before disabling `free-space-tree`, check whether the feature is available:                                                                                                                                    

   1. First try `-O list-all` (filesystem feature — newer btrfs-progs)                                                                                                                                            
   2. If not found, try `-R list-all` (runtime feature — older btrfs-progs)                                                                                                                                       
   3. If neither lists it, skip the flag entirely (feature not supported, no need to disable)                                                                                                                     

Applied to both `setup_partition.sh` and `setup_partition-rk3566.sh`.                                                                                                                                          

## Testing                                                                                                                                                                                                     

Built successfully on Debian bookworm where `free-space-tree` is a runtime (`-R`) feature.                                                                                                                     
