### PR TITLE
Build Amiberry emulator for BATLEXP G350

### DIFF
--- a/amiberry/amiberry.sh
+++ b/amiberry/amiberry.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+pushd "/opt/amiberry/" >/dev/null
+
+filename=$(basename -- "$1")
+extension="${filename##*.}"
+filename="${filename%.*}"
+
+if [[ $extension == "lha" ]]; then
+   /opt/amiberry/amiberry --autoload "$1"
+else
+   /opt/amiberry/amiberry -G -0 "$1"
+fi

--- a/amiberry/amiberry.sh
+++ b/amiberry/amiberry.sh
@@ -1,12 +1,49 @@
 #!/usr/bin/env bash
+
+# AmiBerry launcher with automatic retry on segfault.
+# Root cause: AmiBerry v5.6.8 segfaults during SDL2 KMS/DRM video init
+# when EmulationStation hasn't fully released DRM master. Retrying works.
+
+# Ensure XDG_RUNTIME_DIR exists (cleaned up between ES game launches)
+if [[ ! -d "/run/user/1000" ]]; then
+  mkdir -p /run/user/1000
+  chown 1000:1000 /run/user/1000
+  chmod 700 /run/user/1000
+fi
+export XDG_RUNTIME_DIR=/run/user/1000/
+
+# Give GPU time to settle after perfmax governor/freq change
+sleep 0.5
+
 pushd "/opt/amiberry/" >/dev/null
 
 filename=$(basename -- "$1")
 extension="${filename##*.}"
-filename="${filename%.*}"
 
-if [[ $extension == "lha" ]]; then
-   /opt/amiberry/amiberry --autoload "$1"
-else
-   /opt/amiberry/amiberry -G -0 "$1"
-fi
+# Launch AmiBerry with automatic retry on segfault (exit 139)
+MAX_RETRIES=5
+ATTEMPT=0
+
+while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  if [[ $extension == "lha" ]]; then
+    /opt/amiberry/amiberry --autoload "$1"
+  else
+    /opt/amiberry/amiberry -G -0 "$1"
+  fi
+
+  EXITCODE=$?
+
+  if [[ $EXITCODE -eq 139 ]]; then
+    # Segfault — retry after short delay (DRM master may still be held)
+    if [[ $ATTEMPT -le $MAX_RETRIES ]]; then
+      sleep 0.5
+    fi
+  else
+    break
+  fi
+done
+
+popd >/dev/null
+exit $EXITCODE

--- a/build_amiberrysa.sh
+++ b/build_amiberrysa.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Build and install Amiberry standalone emulator
+if [ -f "Arkbuild_package_cache/${CHIPSET}/amiberrysa.tar.gz" ] && [ "$(cat Arkbuild_package_cache/${CHIPSET}/amiberrysa.commit)" == "$(curl -s https://raw.githubusercontent.com/christianhaitian/${CHIPSET}_core_builds/refs/heads/master/scripts/amiberry.sh | grep -oP '(?<=TAG=").*?(?=")')" ]; then
+    sudo tar -xvzpf Arkbuild_package_cache/${CHIPSET}/amiberrysa.tar.gz
+else
+	call_chroot "cd /home/ark &&
+	  cd ${CHIPSET}_core_builds &&
+	  chmod 777 builds-alt.sh &&
+	  eatmydata ./builds-alt.sh amiberry
+	  "
+	
+	# Check if the chroot build succeeded
+	if [ ! -d "Arkbuild/home/ark/${CHIPSET}_core_builds/amiberry64" ]; then
+	  echo "ERROR: Amiberry build failed - amiberry64 directory not found"
+	  exit 1
+	fi
+	
+	sudo mkdir -p Arkbuild/opt/amiberry
+	sudo cp -a Arkbuild/home/ark/${CHIPSET}_core_builds/amiberry64/* Arkbuild/opt/amiberry/
+	if [ -f "Arkbuild_package_cache/${CHIPSET}/amiberrysa.tar.gz" ]; then
+	  sudo rm -f Arkbuild_package_cache/${CHIPSET}/amiberrysa.tar.gz
+	fi
+	if [ -f "Arkbuild_package_cache/${CHIPSET}/amiberrysa.commit" ]; then
+	  sudo rm -f Arkbuild_package_cache/${CHIPSET}/amiberrysa.commit
+	fi
+	sudo tar -czpf Arkbuild_package_cache/${CHIPSET}/amiberrysa.tar.gz Arkbuild/opt/amiberry/
+	sudo curl -s https://raw.githubusercontent.com/christianhaitian/${CHIPSET}_core_builds/refs/heads/master/scripts/amiberry.sh | grep -oP '(?<=TAG=").*?(?=")' > Arkbuild_package_cache/${CHIPSET}/amiberrysa.commit
+fi
+
+# Copy the wrapper script to /usr/local/bin
+if [ -d "amiberry" ]; then
+  sudo cp -a amiberry/amiberry* Arkbuild/usr/local/bin/
+fi
+
+call_chroot "chown -R ark:ark /opt/"
+sudo chmod 777 Arkbuild/opt/amiberry/*
+if ls Arkbuild/usr/local/bin/amiberry* 1> /dev/null 2>&1; then
+  sudo chmod 777 Arkbuild/usr/local/bin/amiberry*
+fi

--- a/build_amiberrysa.sh
+++ b/build_amiberrysa.sh
@@ -28,6 +28,10 @@ else
 	sudo curl -s https://raw.githubusercontent.com/christianhaitian/${CHIPSET}_core_builds/refs/heads/master/scripts/amiberry.sh | grep -oP '(?<=TAG=").*?(?=")' > Arkbuild_package_cache/${CHIPSET}/amiberrysa.commit
 fi
 
+# Ensure AmiBerry runtime dependencies are in the image
+# (cache-only builds skip the chroot build step where amiberry.sh would install these)
+call_chroot "apt-get -y install --no-install-recommends libserialport0 libportmidi0"
+
 # Copy the wrapper script to /usr/local/bin
 if [ -d "amiberry" ]; then
   sudo cp -a amiberry/amiberry* Arkbuild/usr/local/bin/

--- a/build_g350.sh
+++ b/build_g350.sh
@@ -71,6 +71,7 @@ source ./build_flycastsa.sh
 source ./build_sdljoytest.sh
 source ./build_controllertester.sh
 source ./build_drastic.sh
+source ./build_amiberrysa.sh
 source ./finishing_touches.sh
 source ./cleanup_filesystem.sh
 source ./write_rootfs.sh

--- a/needed_dev_packages.txt
+++ b/needed_dev_packages.txt
@@ -20,6 +20,7 @@ libfreeimage-dev
 libfreetype-dev
 libinih-dev
 libluajit-5.1-dev
+libmpeg2-4-dev
 libncurses-dev
 libnl-3-dev
 libnl-genl-3-dev


### PR DESCRIPTION
Builds Amiberry emulator when building for the BATLEXP G350. Requires https://github.com/christianhaitian/rk3326_core_builds/pull/12 to be merged.