### PR TITLE
Fix wget filename issue for Mali library download

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -62,7 +62,7 @@ do
     FOLDER="armhf"
   fi
   sudo mkdir -p Arkbuild/usr/lib/${ARCHITECTURE}/
-  wget -t 3 -T 60 --no-check-certificate https://github.com/christianhaitian/${CHIPSET}_core_builds/raw/refs/heads/master/mali/${FOLDER}/${whichmali}
+  wget -t 3 -T 60 --no-check-certificate -O ${whichmali} https://github.com/christianhaitian/${CHIPSET}_core_builds/raw/refs/heads/master/mali/${FOLDER}/${whichmali}
   sudo mv ${whichmali} Arkbuild/usr/lib/${ARCHITECTURE}/.
   cd Arkbuild/usr/lib/${ARCHITECTURE}
   sudo ln -sf ${whichmali} libMali.so


### PR DESCRIPTION
Add -O ${whichmali} flag to wget command to force correct filename when downloading libmali from GitHub. Without this, wget may append .1 to the filename (due to Content-Disposition header or existing files), causing the mv command to fail silently. In a build, this resulted in dangling symlinks for libEGL.so → libMali.so → libmali-bifrost-g31-rxp0-gbm.so, which caused libgo2 to fail to link (file too short error), which in turn caused EmulationStation to fail to build (missing go2/audio.h header).