### PR TITLE
Fix non-deterministic EASYROMS mount on dual-SD devices

### DIFF
--- a/finishing_touches.sh
+++ b/finishing_touches.sh
@@ -86,6 +86,12 @@ sudo cp scripts/firstboot.sh ${mountpoint}/firstboot.sh
 sudo cp scripts/firstboot.service Arkbuild/etc/systemd/system/firstboot.service
 sudo chroot Arkbuild/ bash -c "systemctl enable firstboot"
 
+# Add dual-SD external roms mount fix
+sudo cp scripts/mount-external-roms.sh Arkbuild/usr/local/bin/mount-external-roms.sh
+sudo chmod 755 Arkbuild/usr/local/bin/mount-external-roms.sh
+sudo cp scripts/mount-external-roms.service Arkbuild/etc/systemd/system/mount-external-roms.service
+sudo chroot Arkbuild/ bash -c "systemctl enable mount-external-roms"
+
 # Add hotkeydaemon service and python script
 sudo cp hotkeydaemon/killer_daemon.service Arkbuild/etc/systemd/system/killer_daemon.service
 sudo cp hotkeydaemon/killer_daemon.py Arkbuild/usr/local/bin/killer_daemon.py

--- a/scripts/mount-external-roms.service
+++ b/scripts/mount-external-roms.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ensure external SD card EASYROMS is mounted at /roms on dual-SD devices
+After=local-fs.target
+Before=emulationstation.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/mount-external-roms.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/mount-external-roms.sh
+++ b/scripts/mount-external-roms.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# mount-external-roms.sh — On dual-SD devices, ensure external card's EASYROMS is at /roms
+#
+# Problem: When both SD cards have a partition labelled EASYROMS, fstab's LABEL=EASYROMS
+# resolves non-deterministically via udev. ~40% of boots mount the system card's EASYROMS
+# instead of the external games card.
+#
+# This script runs after local-fs.target (after fstab mounts) and before emulationstation.
+# If /roms is mounted from the system card but an external card with EASYROMS also exists,
+# it swaps to the external card.
+
+MOUNT_POINT="/roms"
+
+# Find what's currently mounted at /roms
+CURRENT_DEV=$(findmnt -n -o SOURCE "$MOUNT_POINT" 2>/dev/null)
+if [ -z "$CURRENT_DEV" ]; then
+    # /roms not mounted at all — nothing to do (no EASYROMS partition found by fstab)
+    exit 0
+fi
+
+# If already mounted from a non-mmcblk0 device, it's already correct
+if ! echo "$CURRENT_DEV" | grep -q "^/dev/mmcblk0"; then
+    exit 0
+fi
+
+# System card is mounted at /roms. Check if there's another EASYROMS partition.
+# Scan all mmcblk devices besides mmcblk0 for an EASYROMS label.
+EXTERNAL_DEV=""
+for dev in /dev/mmcblk[1-9]*; do
+    [ -b "$dev" ] || continue
+    LABEL=$(blkid -o value -s LABEL "$dev" 2>/dev/null)
+    if [ "$LABEL" = "EASYROMS" ]; then
+        EXTERNAL_DEV="$dev"
+        break
+    fi
+done
+
+# No external EASYROMS found — single card setup, leave as is
+if [ -z "$EXTERNAL_DEV" ]; then
+    exit 0
+fi
+
+# Swap: unmount system card's EASYROMS, mount external card's
+
+# Unmount bind mount at /opt/system/Tools first (depends on /roms)
+if mountpoint -q /opt/system/Tools 2>/dev/null; then
+    umount /opt/system/Tools 2>/dev/null
+fi
+
+# Unmount /roms
+if ! umount "$MOUNT_POINT" 2>/dev/null; then
+    exit 1
+fi
+
+# Mount from external card
+if ! mount -t exfat -o defaults,umask=000,uid=1000,gid=1000,noatime "$EXTERNAL_DEV" "$MOUNT_POINT" 2>/dev/null; then
+    # Fallback: try to remount the original device
+    mount -t exfat -o defaults,umask=000,uid=1000,gid=1000,noatime "$CURRENT_DEV" "$MOUNT_POINT" 2>/dev/null
+    exit 1
+fi
+
+# Restore bind mount
+if [ -d "$MOUNT_POINT/tools" ]; then
+    mount --bind "$MOUNT_POINT/tools" /opt/system/Tools 2>/dev/null
+fi


### PR DESCRIPTION
On dual-SD devices (e.g. RG351V, RG351MP, G350), both the system SD card and the external SD card have a partition labelled EASYROMS. This is a clever way to have a single image that works with or without a second SD card, no user configuration needed. However, the fstab entry 'LABEL=EASYROMS /roms exfat ...' resolves via udev, which is non-deterministic when two partitions share the same label.

Testing on the BATLEXP G350 showed ~40% of boots mounted the system card's EASYROMS at /roms instead of the external games card.

The fix: a systemd service (mount-external-roms) runs after local-fs.target but before emulationstation. If /roms is mounted from mmcblk0 (system card) and an external card with EASYROMS also exists, it swaps the mount to the external card. No-op on single-SD devices and when fstab already picked the correct card.