### PR TITLE
Expose /roms2/themes to ES via the user themes path

### DIFF
--- a/finishing_touches-rk3566.sh
+++ b/finishing_touches-rk3566.sh
@@ -285,6 +285,10 @@ sudo chmod 777 Arkbuild/usr/local/bin/*
 sudo rm -rf Arkbuild/etc/emulationstation/themes/
 sudo chroot Arkbuild/ bash -c "ln -sfv /roms/themes/ /etc/emulationstation/themes"
 
+# Also expose /roms2/themes via the user themes path so ES picks up themes
+# from the second SD card in SD2-for-Roms mode (dangles harmlessly otherwise).
+sudo chroot Arkbuild/ bash -c "ln -sfv /roms2/themes/ /home/ark/.emulationstation/themes"
+
 # Link music folder to /roms/bgmusic
 sudo rm -rf Arkbuild/home/ark/.emulationstation/music
 sudo chroot Arkbuild/ bash -c "ln -sfv /roms/bgmusic/ /home/ark/.emulationstation/music"

--- a/finishing_touches.sh
+++ b/finishing_touches.sh
@@ -277,6 +277,10 @@ sudo chmod 777 Arkbuild/usr/local/bin/*
 sudo rm -rf Arkbuild/etc/emulationstation/themes/
 sudo chroot Arkbuild/ bash -c "ln -sfv /roms/themes/ /etc/emulationstation/themes"
 
+# Also expose /roms2/themes via the user themes path so ES picks up themes
+# from the second SD card in SD2-for-Roms mode (dangles harmlessly otherwise).
+sudo chroot Arkbuild/ bash -c "ln -sfv /roms2/themes/ /home/ark/.emulationstation/themes"
+
 # Link music folder to /roms/bgmusic
 sudo rm -rf Arkbuild/home/ark/.emulationstation/music
 sudo chroot Arkbuild/ bash -c "ln -sfv /roms/bgmusic/ /home/ark/.emulationstation/music"


### PR DESCRIPTION
EmulationStation already scans two theme paths ([`ThemeData.cpp:1306-1310`](https://github.com/christianhaitian/EmulationStation-fcamod/blob/master/es-core/src/ThemeData.cpp#L1306-L1310)): `/etc/emulationstation/themes` and `$HOME/.emulationstation/themes`. dArkOS uses the first via a symlink to `/roms/themes/` but leaves the second unused.

Symlink the second path to `/roms2/themes/` so themes on the second SD card show up alongside themes on the main SD when in SD2-for-Roms mode. In main-SD mode the symlink dangles, ES's `isDirectory()` check returns false, and that path is skipped silently — no behavior change in single-SD mode.