### PR TITLE
Restore: stop NetworkManager during extract to avoid 0-byte .nmconnection files

### DIFF
--- a/dArkOS_Tools/Advanced/Restore dArkOS Settings.sh
+++ b/dArkOS_Tools/Advanced/Restore dArkOS Settings.sh
@@ -41,8 +41,14 @@ do
 
 		sudo chmod 666 /dev/tty1
 
+		# Stop NetworkManager during extract to prevent its inotify watcher on
+		# /etc/NetworkManager/system-connections/ from racing tar's writes and
+		# leaving the .nmconnection files at 0 bytes.
+		sudo systemctl stop NetworkManager
 		sudo tar --same-owner -zxhvf "$BACKUP_FILE" -C / | tee -a "$LOG_FILE"
-		if [ $? -eq 0 ]; then
+		TAR_STATUS=$?
+		sudo systemctl start NetworkManager
+		if [ $TAR_STATUS -eq 0 ]; then
 			# Properly restore previously set timezone
 			[ -f /dev/shm/TZ ] && ln -sf /usr/share/zoneinfo/$(cat /dev/shm/TZ) /etc/localtime && sudo rm /dev/shm/TZ
 			# Properly restore preferred Switch button tap to off state


### PR DESCRIPTION
On a backup that includes `/etc/NetworkManager/system-connections/*.nmconnection` files, Restore extracts the tar with NM still running. NM's inotify watcher on that directory races tar's per-file `open(O_TRUNC) → write → close → utimes` sequence, and the `.nmconnection` files end up empty (0 bytes) on disk — with the original mtime preserved by tar so the corruption isn't immediately obvious. After reboot, NM logs `failed to load connection: invalid connection: connection.type: property is missing` for each one and skips it. The networks appear in the UI by filename but can't authenticate.

Verified by extracting the same tar to `/tmp` (no watcher in scope) → files come out at their correct 286/290 byte sizes, vs 0 bytes when extracted into the live `/etc/NetworkManager/system-connections/`.

Fix: stop NetworkManager around the tar extraction, capture tar's exit status into a variable so `systemctl start` doesn't clobber `$?` before the success check, then start NM again.