### PR TITLE
Add Global Hotkey Switcher with auto-detection, Low Battery Suspend daemon, and Linux 4.4 uinput fix

### DIFF
--- a/dArkOS_Tools/Advanced/Low Battery Suspend.sh
+++ b/dArkOS_Tools/Advanced/Low Battery Suspend.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Low Battery Suspend Configuration Tool for dArkOS
+# Low Battery Suspend Configuration Tool for dArkOS with i18n support
 # Manages automatic suspend when battery drops below safety threshold
 
 sudo chmod 666 /dev/tty1 2>/dev/null
@@ -7,7 +7,7 @@ export TERM=linux
 export XDG_RUNTIME_DIR=/run/user/$UID/
 
 height="15"
-width="55"
+width="58"
 
 if compgen -G "/boot/rk3566*" > /dev/null; then
   if test ! -z "$(cat /home/ark/.config/.DEVICE | grep RGB20PRO | tr -d '\0')"
@@ -17,10 +17,68 @@ if compgen -G "/boot/rk3566*" > /dev/null; then
     sudo setfont /usr/share/consolefonts/Lat7-TerminusBold28x14.psf.gz
   fi
   height="20"
-  width="60"
+  width="66"
 else
   sudo setfont /usr/share/consolefonts/Lat7-TerminusBold22x11.psf.gz 2>/dev/null || sudo setfont /usr/share/consolefonts/Lat7-Terminus16.psf.gz
 fi
+
+# Detect system / EmulationStation language
+get_language() {
+  local lang
+  if [ -f "/home/ark/.emulationstation/es_settings.cfg" ]; then
+    lang=$(grep '<string name="Language"' /home/ark/.emulationstation/es_settings.cfg 2>/dev/null | sed -n 's/.*value="\([^"]*\)".*/\1/p' | tr '[:upper:]' '[:lower:]')
+  fi
+  if [ -z "$lang" ] && [ -f "/home/ark/.config/.LANGUAGE" ]; then
+    lang=$(cat /home/ark/.config/.LANGUAGE 2>/dev/null | tr -dc 'a-zA-Z_' | tr '[:upper:]' '[:lower:]')
+  fi
+  [ -z "$lang" ] && lang="${LANG:0:2}"
+  [ -z "$lang" ] && lang="en"
+  echo "${lang:0:2}"
+}
+
+LANG_CODE=$(get_language)
+
+# i18n Strings
+case "$LANG_CODE" in
+  pl)
+    T_TITLE="Ochrona Baterii dArkOS"
+    T_STATUS_LABEL="Status"
+    T_ACTIVE="Aktywna (Prog: %s%%)"
+    T_DISABLED="Wylaczona"
+    T_MENU="Wybierz opcje ochrony baterii:"
+    T_OPT_5="1. Wlacz / Ustaw prog na 5% (Zalecane)"
+    T_OPT_10="2. Wlacz / Ustaw prog na 10%"
+    T_OPT_15="3. Wlacz / Ustaw prog na 15%"
+    T_OPT_DIS="4. Wylacz usypianie przy niskiej baterii"
+    T_OPT_TEST="5. Testuj usypianie teraz (Natychmiastowy sen)"
+    T_OPT_EXIT="6. Wyjscie"
+    T_EXIT_BTN="Wyjscie"
+    T_CONFIGURING="Konfigurowanie usypiania przy niskiej baterii (%s%%)...\nProsze czekac..."
+    T_ENABLED_MSG="Usypianie przy niskiej baterii zostalo wlaczone!\n\n- Prog: %s%%\n- Sprawdzanie co 30s (po 3 niskich odczytach)\n- Automatycznie usypia konsole, chroniac przed naglym rozladowaniem"
+    T_DISABLING="Wylaczanie ochrony baterii...\nProsze czekac..."
+    T_DISABLED_MSG="Usypianie przy niskiej baterii zostalo wylaczone."
+    T_TEST_PROMPT="Czy chcesz przetestowac natychmiastowe usypianie?\n\nAby wybudzic konsole, nacisnij przycisk POWER."
+    ;;
+  *)
+    T_TITLE="dArkOS Low Battery Protection"
+    T_STATUS_LABEL="Status"
+    T_ACTIVE="Active (Threshold: %s%%)"
+    T_DISABLED="Disabled"
+    T_MENU="Select battery protection option:"
+    T_OPT_5="1. Enable / Set Threshold to 5% (Recommended)"
+    T_OPT_10="2. Enable / Set Threshold to 10%"
+    T_OPT_15="3. Enable / Set Threshold to 15%"
+    T_OPT_DIS="4. Disable Low Battery Suspend"
+    T_OPT_TEST="5. Test Suspend Now (Instant Sleep)"
+    T_OPT_EXIT="6. Exit"
+    T_EXIT_BTN="Exit"
+    T_CONFIGURING="Configuring Low Battery Suspend (%s%%)...\nPlease wait..."
+    T_ENABLED_MSG="Low Battery Suspend enabled!\n\n- Threshold: %s%%\n- Checks every 30s (triggers after 3 readings)\n- Automatically suspends console safely to prevent abrupt power loss"
+    T_DISABLING="Disabling Low Battery Suspend...\nPlease wait..."
+    T_DISABLED_MSG="Low Battery Suspend has been disabled."
+    T_TEST_PROMPT="Would you like to test instant suspend now?\n\nPress Power button to wake the console."
+    ;;
+esac
 
 # Controls for dialog
 if [[ -z $(pgrep -f gptokeyb) ]]; then
@@ -49,15 +107,17 @@ get_status() {
     local thr
     thr=$(cat "$CONF" 2>/dev/null | tr -dc '0-9')
     [ -z "$thr" ] && thr=5
-    echo "Active (Threshold: ${thr}%)"
+    printf "$T_ACTIVE" "$thr"
   else
-    echo "Disabled"
+    echo "$T_DISABLED"
   fi
 }
 
 install_daemon() {
   local thr="$1"
-  dialog --infobox "\nConfiguring Low Battery Suspend (${thr}%)...\nPlease wait..." 6 $width > /dev/tty1
+  local info_msg
+  info_msg=$(printf "$T_CONFIGURING" "$thr")
+  dialog --infobox "\n$info_msg" 6 $width > /dev/tty1
 
   echo "$thr" > "$CONF"
   chown ark:ark "$CONF" 2>/dev/null
@@ -136,19 +196,21 @@ EOF
   sudo systemctl enable lowbatt-suspend.service > /dev/null 2>&1
   sudo systemctl restart lowbatt-suspend.service
 
-  dialog --msgbox "\nLow Battery Suspend enabled!\n\n- Threshold: ${thr}%\n- Checks every 30s (triggers after 3 readings)\n- Automatically suspends console safely to prevent abrupt power loss" 10 $width > /dev/tty1
+  local succ_msg
+  succ_msg=$(printf "$T_ENABLED_MSG" "$thr")
+  dialog --msgbox "\n$succ_msg" 10 $width > /dev/tty1
 }
 
 disable_daemon() {
-  dialog --infobox "\nDisabling Low Battery Suspend...\nPlease wait..." 5 $width > /dev/tty1
+  dialog --infobox "\n$T_DISABLING" 5 $width > /dev/tty1
   sudo systemctl disable --now lowbatt-suspend.service > /dev/null 2>&1
   sudo rm -f "$UNIT" "$PROG"
   sudo systemctl daemon-reload
-  dialog --msgbox "\nLow Battery Suspend has been disabled." 7 $width > /dev/tty1
+  dialog --msgbox "\n$T_DISABLED_MSG" 7 $width > /dev/tty1
 }
 
 test_suspend() {
-  dialog --yesno "\nWould you like to test instant suspend now?\n\nPress Power button to wake the console." 8 $width > /dev/tty1
+  dialog --yesno "\n$T_TEST_PROMPT" 8 $width > /dev/tty1
   if [ $? -eq 0 ]; then
     sync
     sudo systemctl suspend
@@ -159,21 +221,21 @@ while true; do
   cur_stat=$(get_status)
   
   options=(
-    1 "Enable / Set Threshold to 5% (Recommended)"
-    2 "Enable / Set Threshold to 10%"
-    3 "Enable / Set Threshold to 15%"
-    4 "Disable Low Battery Suspend"
-    5 "Test Suspend Now (Instant Sleep)"
-    6 "Exit"
+    1 "$T_OPT_5"
+    2 "$T_OPT_10"
+    3 "$T_OPT_15"
+    4 "$T_OPT_DIS"
+    5 "$T_OPT_TEST"
+    6 "$T_OPT_EXIT"
   )
 
   selection=(dialog \
-    --backtitle "dArkOS Low Battery Protection" \
-    --title "Status: $cur_stat" \
+    --backtitle "$T_TITLE" \
+    --title "$T_STATUS_LABEL: $cur_stat" \
     --no-collapse \
     --clear \
-    --cancel-label "Exit" \
-    --menu "Select an option:" $height $width 15)
+    --cancel-label "$T_EXIT_BTN" \
+    --menu "$T_MENU" $height $width 15)
 
   choice=$("${selection[@]}" "${options[@]}" 2>&1 > /dev/tty1)
   if [ $? -ne 0 ]; then

--- a/dArkOS_Tools/Advanced/Low Battery Suspend.sh
+++ b/dArkOS_Tools/Advanced/Low Battery Suspend.sh
@@ -164,6 +164,9 @@ while true; do
     logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
     if [ "$low_count" -ge "$NEEDED" ]; then
       logger -t lowbatt "suspending console at ${cap}% battery"
+      # Voice warning announcement
+      /usr/local/bin/speak_bat_life.sh critical_suspend >/dev/null 2>&1 &
+      sleep 4
       sync
       /bin/systemctl suspend
       low_count=0

--- a/dArkOS_Tools/Advanced/Low Battery Suspend.sh
+++ b/dArkOS_Tools/Advanced/Low Battery Suspend.sh
@@ -164,9 +164,8 @@ while true; do
     logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
     if [ "$low_count" -ge "$NEEDED" ]; then
       logger -t lowbatt "suspending console at ${cap}% battery"
-      # Voice warning announcement
-      /usr/local/bin/speak_bat_life.sh critical_suspend >/dev/null 2>&1 &
-      sleep 4
+      # Play voice warning and suspend immediately when finished
+      /usr/local/bin/speak_bat_life.sh critical_suspend
       sync
       /bin/systemctl suspend
       low_count=0

--- a/dArkOS_Tools/Advanced/Low Battery Suspend.sh
+++ b/dArkOS_Tools/Advanced/Low Battery Suspend.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Low Battery Suspend Configuration Tool for dArkOS
+# Manages automatic suspend when battery drops below safety threshold
+
+sudo chmod 666 /dev/tty1 2>/dev/null
+export TERM=linux
+export XDG_RUNTIME_DIR=/run/user/$UID/
+
+height="15"
+width="55"
+
+if compgen -G "/boot/rk3566*" > /dev/null; then
+  if test ! -z "$(cat /home/ark/.config/.DEVICE | grep RGB20PRO | tr -d '\0')"
+  then
+    sudo setfont /usr/share/consolefonts/Lat7-TerminusBold32x16.psf.gz
+  else
+    sudo setfont /usr/share/consolefonts/Lat7-TerminusBold28x14.psf.gz
+  fi
+  height="20"
+  width="60"
+else
+  sudo setfont /usr/share/consolefonts/Lat7-TerminusBold22x11.psf.gz 2>/dev/null || sudo setfont /usr/share/consolefonts/Lat7-Terminus16.psf.gz
+fi
+
+# Controls for dialog
+if [[ -z $(pgrep -f gptokeyb) ]]; then
+  sudo chmod 666 /dev/uinput 2>/dev/null
+  export SDL_GAMECONTROLLERCONFIG_FILE="/opt/inttools/gamecontrollerdb.txt"
+  /opt/inttools/gptokeyb -c "/opt/inttools/keys.gptk" > /dev/null 2>&1 &
+  disown
+  set_gptokeyb="Y"
+fi
+
+clean_exit() {
+  printf "\033c" > /dev/tty1
+  if [[ ! -z "$set_gptokeyb" ]] || [[ ! -z $(pgrep -f gptokeyb) ]]; then
+    pgrep -f gptokeyb | sudo xargs kill -9 2>/dev/null
+    unset SDL_GAMECONTROLLERCONFIG_FILE
+  fi
+  exit 0
+}
+
+CONF="/home/ark/.config/.LOWBATT"
+PROG="/usr/local/bin/lowbatt_suspend.sh"
+UNIT="/etc/systemd/system/lowbatt-suspend.service"
+
+get_status() {
+  if systemctl is-active --quiet lowbatt-suspend.service 2>/dev/null; then
+    local thr
+    thr=$(cat "$CONF" 2>/dev/null | tr -dc '0-9')
+    [ -z "$thr" ] && thr=5
+    echo "Active (Threshold: ${thr}%)"
+  else
+    echo "Disabled"
+  fi
+}
+
+install_daemon() {
+  local thr="$1"
+  dialog --infobox "\nConfiguring Low Battery Suspend (${thr}%)...\nPlease wait..." 6 $width > /dev/tty1
+
+  echo "$thr" > "$CONF"
+  chown ark:ark "$CONF" 2>/dev/null
+
+  sudo tee "$PROG" > /dev/null <<'EOF'
+#!/bin/bash
+# Suspend console when battery drops below threshold and not charging.
+CONF=/home/ark/.config/.LOWBATT
+CAP=/sys/class/power_supply/battery/capacity
+INTERVAL=30
+NEEDED=3
+
+low_count=0
+
+read_threshold() {
+  local t
+  t=$(cat "$CONF" 2>/dev/null | tr -dc '0-9')
+  [ -z "$t" ] && t=5
+  [ "$t" -lt 1 ] && t=1
+  [ "$t" -gt 50 ] && t=50
+  echo "$t"
+}
+
+is_charging() {
+  grep -qi "charging" /sys/class/power_supply/*/status 2>/dev/null || \
+  grep -q "1" /sys/class/power_supply/*/online 2>/dev/null
+}
+
+while true; do
+  sleep "$INTERVAL"
+  [ -r "$CAP" ] || continue
+
+  cap=$(cat "$CAP" 2>/dev/null | tr -dc '0-9')
+  [ -z "$cap" ] && continue
+
+  if is_charging; then
+    low_count=0
+    continue
+  fi
+
+  thr=$(read_threshold)
+  if [ "$cap" -le "$thr" ]; then
+    low_count=$((low_count+1))
+    logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
+    if [ "$low_count" -ge "$NEEDED" ]; then
+      logger -t lowbatt "suspending console at ${cap}% battery"
+      sync
+      /bin/systemctl suspend
+      low_count=0
+      sleep 120
+    fi
+  else
+    low_count=0
+  fi
+done
+EOF
+  sudo chmod +x "$PROG"
+
+  sudo tee "$UNIT" > /dev/null <<'EOF'
+[Unit]
+Description=Suspend on low battery
+After=multi-user.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/lowbatt_suspend.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable lowbatt-suspend.service > /dev/null 2>&1
+  sudo systemctl restart lowbatt-suspend.service
+
+  dialog --msgbox "\nLow Battery Suspend enabled!\n\n- Threshold: ${thr}%\n- Checks every 30s (triggers after 3 readings)\n- Automatically suspends console safely to prevent abrupt power loss" 10 $width > /dev/tty1
+}
+
+disable_daemon() {
+  dialog --infobox "\nDisabling Low Battery Suspend...\nPlease wait..." 5 $width > /dev/tty1
+  sudo systemctl disable --now lowbatt-suspend.service > /dev/null 2>&1
+  sudo rm -f "$UNIT" "$PROG"
+  sudo systemctl daemon-reload
+  dialog --msgbox "\nLow Battery Suspend has been disabled." 7 $width > /dev/tty1
+}
+
+test_suspend() {
+  dialog --yesno "\nWould you like to test instant suspend now?\n\nPress Power button to wake the console." 8 $width > /dev/tty1
+  if [ $? -eq 0 ]; then
+    sync
+    sudo systemctl suspend
+  fi
+}
+
+while true; do
+  cur_stat=$(get_status)
+  
+  options=(
+    1 "Enable / Set Threshold to 5% (Recommended)"
+    2 "Enable / Set Threshold to 10%"
+    3 "Enable / Set Threshold to 15%"
+    4 "Disable Low Battery Suspend"
+    5 "Test Suspend Now (Instant Sleep)"
+    6 "Exit"
+  )
+
+  selection=(dialog \
+    --backtitle "dArkOS Low Battery Protection" \
+    --title "Status: $cur_stat" \
+    --no-collapse \
+    --clear \
+    --cancel-label "Exit" \
+    --menu "Select an option:" $height $width 15)
+
+  choice=$("${selection[@]}" "${options[@]}" 2>&1 > /dev/tty1)
+  if [ $? -ne 0 ]; then
+    clean_exit
+  fi
+
+  case $choice in
+    1) install_daemon 5 ;;
+    2) install_daemon 10 ;;
+    3) install_daemon 15 ;;
+    4) disable_daemon ;;
+    5) test_suspend ;;
+    6) clean_exit ;;
+  esac
+done

--- a/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
+++ b/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Switch Global Hotkey Tool for dArkOS
+# Allows switching hotkey between FN (Button 16), SELECT (Button 12), and R3 (Button 15)
+
+sudo chmod 666 /dev/tty1 2>/dev/null
+export TERM=linux
+export XDG_RUNTIME_DIR=/run/user/$UID/
+
+height="15"
+width="55"
+
+if compgen -G "/boot/rk3566*" > /dev/null; then
+  if test ! -z "$(cat /home/ark/.config/.DEVICE | grep RGB20PRO | tr -d '\0')"
+  then
+    sudo setfont /usr/share/consolefonts/Lat7-TerminusBold32x16.psf.gz
+  else
+    sudo setfont /usr/share/consolefonts/Lat7-TerminusBold28x14.psf.gz
+  fi
+  height="20"
+  width="60"
+else
+  sudo setfont /usr/share/consolefonts/Lat7-TerminusBold22x11.psf.gz 2>/dev/null || sudo setfont /usr/share/consolefonts/Lat7-Terminus16.psf.gz
+fi
+
+# Kill old gptokeyb instances and start controls for dialog
+if [[ -z $(pgrep -f gptokeyb) ]]; then
+  sudo chmod 666 /dev/uinput 2>/dev/null
+  export SDL_GAMECONTROLLERCONFIG_FILE="/opt/inttools/gamecontrollerdb.txt"
+  /opt/inttools/gptokeyb -c "/opt/inttools/keys.gptk" > /dev/null 2>&1 &
+  disown
+  set_gptokeyb="Y"
+fi
+
+clean_exit() {
+  printf "\033c" > /dev/tty1
+  if [[ ! -z "$set_gptokeyb" ]] || [[ ! -z $(pgrep -f gptokeyb) ]]; then
+    pgrep -f gptokeyb | sudo xargs kill -9 2>/dev/null
+    unset SDL_GAMECONTROLLERCONFIG_FILE
+  fi
+  exit 0
+}
+
+# Determine current hotkey
+get_current_hotkey_name() {
+  local ra_hk
+  ra_hk=$(grep "^input_enable_hotkey_btn" /home/ark/.config/retroarch/retroarch.cfg 2>/dev/null | cut -d '"' -f 2)
+  if [ "$ra_hk" == "16" ]; then
+    echo "FN Button (Button 16)"
+  elif [ "$ra_hk" == "12" ]; then
+    echo "SELECT Button (Button 12)"
+  elif [ "$ra_hk" == "15" ]; then
+    echo "R3 Button (Button 15)"
+  else
+    echo "Custom (Button $ra_hk)"
+  fi
+}
+
+apply_hotkey() {
+  local btn_id="$1"
+  local btn_name="$2"
+  local ogage_code="$3"   # 0x2c4 for FN, 0x2c0 for SELECT, 0x2c3 for R3
+
+  dialog --infobox "\nSetting Hotkey to $btn_name...\nPlease wait..." 6 $width > /dev/tty1
+
+  # 1. Update RetroArch and RetroArch32 configs
+  for rcfg in /home/ark/.config/retroarch/retroarch.cfg /home/ark/.config/retroarch32/retroarch.cfg; do
+    if [ -f "$rcfg" ]; then
+      sed -i "s/^input_enable_hotkey_btn = .*/input_enable_hotkey_btn = \"$btn_id\"/" "$rcfg"
+    fi
+  done
+
+  # 2. Update EmulationStation input configs
+  for es_cfg in /etc/emulationstation/es_input.cfg /home/ark/.emulationstation/es_input.cfg; do
+    if [ -f "$es_cfg" ]; then
+      sed -i "s/<input name=\"system_hk\" type=\"button\" id=\"[0-9]*\" value=\"1\" \/>/<input name=\"system_hk\" type=\"button\" id=\"$btn_id\" value=\"1\" \/>/" "$es_cfg"
+      sed -i "s/<input name=\"hotkeyenable\" type=\"button\" id=\"[0-9]*\" value=\"1\" \/>/<input name=\"hotkeyenable\" type=\"button\" id=\"$btn_id\" value=\"1\" \/>/" "$es_cfg"
+      sed -i "s/<input name=\"hotkey\" type=\"button\" id=\"[0-9]*\" value=\"1\" \/>/<input name=\"hotkey\" type=\"button\" id=\"$btn_id\" value=\"1\" \/>/" "$es_cfg"
+    fi
+  done
+
+  # 3. Patch ogage binary for brightness modifier
+  if [ -f "/usr/local/bin/ogage" ]; then
+    python3 -c "
+import os, subprocess
+
+src = '/usr/local/bin/ogage'
+target_code = int('$ogage_code', 16) # e.g. 0x2c4, 0x2c0, 0x2c3
+
+with open(src, 'rb') as f:
+    data = bytearray(f.read())
+
+candidates = [
+    bytes([0x1f, 0x01, 0x0b, 0x71]), # 0x2c0 (SELECT)
+    bytes([0x1f, 0x0d, 0x0b, 0x71]), # 0x2c3 (R3)
+    bytes([0x1f, 0x11, 0x0b, 0x71])  # 0x2c4 (FN)
+]
+
+new_imm12 = target_code & 0xfff
+new_val = 0x7100001f | (new_imm12 << 10) | (8 << 5) | 31
+new_bytes = new_val.to_bytes(4, 'little')
+
+count = 0
+for cand in candidates:
+    idx = 0
+    while True:
+        pos = data.find(cand, idx)
+        if pos == -1:
+            break
+        data[pos:pos+4] = new_bytes
+        count += 1
+        idx = pos + 4
+
+if count > 0:
+    with open('/tmp/ogage_patched', 'wb') as f:
+        f.write(data)
+    os.chmod('/tmp/ogage_patched', 0o755)
+    subprocess.run(['sudo', 'systemctl', 'stop', 'ogage.service'], check=True)
+    subprocess.run(['sudo', 'cp', '/tmp/ogage_patched', src], check=True)
+    subprocess.run(['sudo', 'chmod', '755', src], check=True)
+    subprocess.run(['sudo', 'systemctl', 'start', 'ogage.service'], check=True)
+" 2>/dev/null
+  fi
+
+  # 4. Restart EmulationStation
+  sudo systemctl restart emulationstation > /dev/null 2>&1
+
+  dialog --msgbox "\nHotkey successfully changed to:\n$btn_name\n\n- In-game: $btn_name + X (Menu), $btn_name + START (Exit)\n- Brightness: $btn_name + VOL UP / DOWN" 10 $width > /dev/tty1
+}
+
+while true; do
+  cur_hk=$(get_current_hotkey_name)
+  
+  options=(
+    1 "Set Hotkey to FN Button (Button 16 - R36S Default)"
+    2 "Set Hotkey to SELECT Button (Button 12 - ArkOS Classic)"
+    3 "Set Hotkey to R3 Button (Button 15 - Right Stick Click)"
+    4 "Exit"
+  )
+
+  selection=(dialog \
+    --backtitle "dArkOS Global Hotkey Switcher" \
+    --title "Current Hotkey: $cur_hk" \
+    --no-collapse \
+    --clear \
+    --cancel-label "Exit" \
+    --menu "Select your desired Hotkey:" $height $width 15)
+
+  choice=$("${selection[@]}" "${options[@]}" 2>&1 > /dev/tty1)
+  if [ $? -ne 0 ]; then
+    clean_exit
+  fi
+
+  case $choice in
+    1) apply_hotkey "16" "FN Button (Button 16)" "0x2c4" ;;
+    2) apply_hotkey "12" "SELECT Button (Button 12)" "0x2c0" ;;
+    3) apply_hotkey "15" "R3 Button (Button 15)" "0x2c3" ;;
+    4) clean_exit ;;
+  esac
+done

--- a/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
+++ b/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Switch Global Hotkey Tool for dArkOS
+# Switch Global Hotkey Tool for dArkOS with i18n support
 # Allows interactive button detection (press any button) or selecting presets
 
 sudo chmod 666 /dev/tty1 2>/dev/null
@@ -7,7 +7,7 @@ export TERM=linux
 export XDG_RUNTIME_DIR=/run/user/$UID/
 
 height="16"
-width="58"
+width="62"
 
 if compgen -G "/boot/rk3566*" > /dev/null; then
   if test ! -z "$(cat /home/ark/.config/.DEVICE | grep RGB20PRO | tr -d '\0')"
@@ -17,10 +17,64 @@ if compgen -G "/boot/rk3566*" > /dev/null; then
     sudo setfont /usr/share/consolefonts/Lat7-TerminusBold28x14.psf.gz
   fi
   height="20"
-  width="60"
+  width="66"
 else
   sudo setfont /usr/share/consolefonts/Lat7-TerminusBold22x11.psf.gz 2>/dev/null || sudo setfont /usr/share/consolefonts/Lat7-Terminus16.psf.gz
 fi
+
+# Detect system / EmulationStation language
+get_language() {
+  local lang
+  if [ -f "/home/ark/.emulationstation/es_settings.cfg" ]; then
+    lang=$(grep '<string name="Language"' /home/ark/.emulationstation/es_settings.cfg 2>/dev/null | sed -n 's/.*value="\([^"]*\)".*/\1/p' | tr '[:upper:]' '[:lower:]')
+  fi
+  if [ -z "$lang" ] && [ -f "/home/ark/.config/.LANGUAGE" ]; then
+    lang=$(cat /home/ark/.config/.LANGUAGE 2>/dev/null | tr -dc 'a-zA-Z_' | tr '[:upper:]' '[:lower:]')
+  fi
+  [ -z "$lang" ] && lang="${LANG:0:2}"
+  [ -z "$lang" ] && lang="en"
+  echo "${lang:0:2}"
+}
+
+LANG_CODE=$(get_language)
+
+# i18n Strings
+case "$LANG_CODE" in
+  pl)
+    T_TITLE="Menedzer Globalnego Klawisza Hotkey"
+    T_CUR="Aktualny Hotkey"
+    T_NOT_SET="Nie ustawiono"
+    T_MENU="Wybierz konfiguracje Hotkey:"
+    T_OPT_DETECT="1. Nacisnij klawisz, aby ustawic (Auto-wykrywanie)"
+    T_OPT_FN="2. Przycisk FN (Button 16 - Domyslny R36S)"
+    T_OPT_SEL="3. Przycisk SELECT (Button 12 - Klasyczny ArkOS)"
+    T_OPT_R3="4. Przycisk R3 (Button 15 - Klik prawej galki)"
+    T_OPT_EXIT="5. Wyjscie"
+    T_EXIT_BTN="Wyjscie"
+    T_WAIT_PRESS="--- Nacisnij wybrany przycisk Hotkey ---\n\nNacisnij przycisk na konsoli, ktory ma byc klawiszem funkcyjnym (np. FN, SELECT, MENU, R3)...\n\nOczekiwanie do 15 sekund..."
+    T_TIMEOUT="Nie wykryto nacisniecia przycisku (Timeout).\nSprobuj ponownie."
+    T_CONFIRM="Wykryto przycisk:\n  Nazwa: %s\n  ID Przycisku: %s\n  Kod Linux: %s\n  Urzadzenie: %s\n\nCzy chcesz ustawic ten przycisk jako Globalny Hotkey?"
+    T_SETTING="Ustawianie Hotkey na %s...\nProsze czekac..."
+    T_SUCCESS="Hotkey zostal pomyslnie zmieniony!\n\nNowy Hotkey: %s\nID Przycisku: %s\n\n- W grach: %s + X (Menu), %s + START (Wyjscie)\n- Jasnosc: %s + VOL UP / DOWN"
+    ;;
+  *)
+    T_TITLE="dArkOS Global Hotkey Manager"
+    T_CUR="Current Hotkey"
+    T_NOT_SET="Not Set"
+    T_MENU="Select Hotkey Configuration:"
+    T_OPT_DETECT="1. Press a button to set as Hotkey (Interactive Detect)"
+    T_OPT_FN="2. Set to FN Button (Button 16 - R36S Default)"
+    T_OPT_SEL="3. Set to SELECT Button (Button 12 - ArkOS Classic)"
+    T_OPT_R3="4. Set to R3 Button (Button 15 - Right Stick Click)"
+    T_OPT_EXIT="5. Exit"
+    T_EXIT_BTN="Exit"
+    T_WAIT_PRESS="--- Press Desired Hotkey Button ---\n\nPlease press the button on your console that you want to use as the Hotkey (e.g. FN, SELECT, MENU, R3)...\n\nWaiting up to 15 seconds..."
+    T_TIMEOUT="No button press was detected (Timeout).\nPlease try again."
+    T_CONFIRM="Detected Button:\n  Name: %s\n  Button ID: %s\n  Linux Code: %s\n  Device: %s\n\nSet this button as your Global Hotkey?"
+    T_SETTING="Setting Hotkey to %s...\nPlease wait..."
+    T_SUCCESS="Hotkey successfully configured!\n\nNew Hotkey: %s\nButton ID: %s\n\n- In-game: %s + X (Menu), %s + START (Exit)\n- Brightness: %s + VOL UP / DOWN"
+    ;;
+esac
 
 start_controls() {
   if [[ -z $(pgrep -f gptokeyb) ]]; then
@@ -45,10 +99,8 @@ clean_exit() {
   exit 0
 }
 
-# Start controls on script launch
 start_controls
 
-# Determine current hotkey
 get_current_hotkey_name() {
   local ra_hk
   ra_hk=$(grep "^input_enable_hotkey_btn" /home/ark/.config/retroarch/retroarch.cfg 2>/dev/null | cut -d '"' -f 2)
@@ -61,18 +113,20 @@ get_current_hotkey_name() {
   elif [ ! -z "$ra_hk" ]; then
     echo "Button $ra_hk"
   else
-    echo "Not Set"
+    echo "$T_NOT_SET"
   fi
 }
 
 apply_hotkey() {
   local btn_id="$1"
   local btn_name="$2"
-  local ogage_code="$3"   # e.g. 0x2c4, 0x2c0, 0x2c3
+  local ogage_code="$3"
 
-  dialog --infobox "\nSetting Hotkey to $btn_name...\nPlease wait..." 6 $width > /dev/tty1
+  local info_msg
+  info_msg=$(printf "$T_SETTING" "$btn_name")
+  dialog --infobox "\n$info_msg" 6 $width > /dev/tty1
 
-  # 1. Update RetroArch and RetroArch32 configs
+  # 1. Update RetroArch configs
   for rcfg in /home/ark/.config/retroarch/retroarch.cfg /home/ark/.config/retroarch32/retroarch.cfg; do
     if [ -f "$rcfg" ]; then
       sed -i "s/^input_enable_hotkey_btn = .*/input_enable_hotkey_btn = \"$btn_id\"/" "$rcfg"
@@ -88,7 +142,7 @@ apply_hotkey() {
     fi
   done
 
-  # 3. Patch ogage binary for brightness modifier
+  # 3. Patch ogage binary
   if [ -f "/usr/local/bin/ogage" ] && [ ! -z "$ogage_code" ]; then
     python3 -c "
 import os, subprocess
@@ -134,14 +188,15 @@ if count > 0:
   # 4. Restart EmulationStation
   sudo systemctl restart emulationstation > /dev/null 2>&1
 
-  dialog --msgbox "\nHotkey successfully configured!\n\nNew Hotkey: $btn_name\nButton ID: $btn_id\n\n- In-game: $btn_name + X (Menu), $btn_name + START (Exit)\n- Brightness: $btn_name + VOL UP / DOWN" 12 $width > /dev/tty1
+  local succ_msg
+  succ_msg=$(printf "$T_SUCCESS" "$btn_name" "$btn_id" "$btn_name" "$btn_name" "$btn_name")
+  dialog --msgbox "\n$succ_msg" 12 $width > /dev/tty1
 }
 
 detect_interactive() {
-  # Stop gptokeyb so raw button press can be caught
   stop_controls
 
-  dialog --infobox "\n--- Press Desired Hotkey Button ---\n\nPlease press the button on your console\nthat you want to use as the Hotkey\n(e.g. FN, SELECT, MENU, R3)...\n\nWaiting up to 15 seconds..." 10 $width > /dev/tty1
+  dialog --infobox "\n$T_WAIT_PRESS" 10 $width > /dev/tty1
 
   DETECT_JSON="/tmp/detected_hotkey.json"
   rm -f "$DETECT_JSON"
@@ -203,12 +258,10 @@ def detect():
 detect()
 "
   status=$?
-
-  # Restart controls for navigation
   start_controls
 
   if [ $status -ne 0 ] || [ ! -f "$DETECT_JSON" ]; then
-    dialog --msgbox "\nNo button press was detected (Timeout).\nPlease try again." 7 $width > /dev/tty1
+    dialog --msgbox "\n$T_TIMEOUT" 7 $width > /dev/tty1
     return
   fi
 
@@ -217,7 +270,10 @@ detect()
   detected_hex=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['hex_code'])" 2>/dev/null)
   detected_dev=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['device'])" 2>/dev/null)
 
-  dialog --yesno "\nDetected Button:\n  Name: $detected_name\n  Button ID: $detected_id\n  Linux Code: $detected_hex\n  Device: $detected_dev\n\nSet this button as your Global Hotkey?" 12 $width > /dev/tty1
+  local conf_msg
+  conf_msg=$(printf "$T_CONFIRM" "$detected_name" "$detected_id" "$detected_hex" "$detected_dev")
+
+  dialog --yesno "\n$conf_msg" 13 $width > /dev/tty1
   if [ $? -eq 0 ]; then
     apply_hotkey "$detected_id" "$detected_name" "$detected_hex"
   fi
@@ -227,20 +283,20 @@ while true; do
   cur_hk=$(get_current_hotkey_name)
   
   options=(
-    1 "Press a button to set as Hotkey (Interactive Detect)"
-    2 "Set to FN Button (Button 16 - R36S Default)"
-    3 "Set to SELECT Button (Button 12 - ArkOS Classic)"
-    4 "Set to R3 Button (Button 15 - Right Stick Click)"
-    5 "Exit"
+    1 "$T_OPT_DETECT"
+    2 "$T_OPT_FN"
+    3 "$T_OPT_SEL"
+    4 "$T_OPT_R3"
+    5 "$T_OPT_EXIT"
   )
 
   selection=(dialog \
-    --backtitle "dArkOS Global Hotkey Manager" \
-    --title "Current Hotkey: $cur_hk" \
+    --backtitle "$T_TITLE" \
+    --title "$T_CUR: $cur_hk" \
     --no-collapse \
     --clear \
-    --cancel-label "Exit" \
-    --menu "Select Hotkey Configuration:" $height $width 15)
+    --cancel-label "$T_EXIT_BTN" \
+    --menu "$T_MENU" $height $width 15)
 
   choice=$("${selection[@]}" "${options[@]}" 2>&1 > /dev/tty1)
   if [ $? -ne 0 ]; then

--- a/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
+++ b/dArkOS_Tools/Advanced/Switch Global Hotkey.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # Switch Global Hotkey Tool for dArkOS
-# Allows switching hotkey between FN (Button 16), SELECT (Button 12), and R3 (Button 15)
+# Allows interactive button detection (press any button) or selecting presets
 
 sudo chmod 666 /dev/tty1 2>/dev/null
 export TERM=linux
 export XDG_RUNTIME_DIR=/run/user/$UID/
 
-height="15"
-width="55"
+height="16"
+width="58"
 
 if compgen -G "/boot/rk3566*" > /dev/null; then
   if test ! -z "$(cat /home/ark/.config/.DEVICE | grep RGB20PRO | tr -d '\0')"
@@ -22,23 +22,31 @@ else
   sudo setfont /usr/share/consolefonts/Lat7-TerminusBold22x11.psf.gz 2>/dev/null || sudo setfont /usr/share/consolefonts/Lat7-Terminus16.psf.gz
 fi
 
-# Kill old gptokeyb instances and start controls for dialog
-if [[ -z $(pgrep -f gptokeyb) ]]; then
-  sudo chmod 666 /dev/uinput 2>/dev/null
-  export SDL_GAMECONTROLLERCONFIG_FILE="/opt/inttools/gamecontrollerdb.txt"
-  /opt/inttools/gptokeyb -c "/opt/inttools/keys.gptk" > /dev/null 2>&1 &
-  disown
-  set_gptokeyb="Y"
-fi
+start_controls() {
+  if [[ -z $(pgrep -f gptokeyb) ]]; then
+    sudo chmod 666 /dev/uinput 2>/dev/null
+    export SDL_GAMECONTROLLERCONFIG_FILE="/opt/inttools/gamecontrollerdb.txt"
+    /opt/inttools/gptokeyb -c "/opt/inttools/keys.gptk" > /dev/null 2>&1 &
+    disown
+    set_gptokeyb="Y"
+  fi
+}
 
-clean_exit() {
-  printf "\033c" > /dev/tty1
+stop_controls() {
   if [[ ! -z "$set_gptokeyb" ]] || [[ ! -z $(pgrep -f gptokeyb) ]]; then
     pgrep -f gptokeyb | sudo xargs kill -9 2>/dev/null
     unset SDL_GAMECONTROLLERCONFIG_FILE
   fi
+}
+
+clean_exit() {
+  printf "\033c" > /dev/tty1
+  stop_controls
   exit 0
 }
+
+# Start controls on script launch
+start_controls
 
 # Determine current hotkey
 get_current_hotkey_name() {
@@ -50,15 +58,17 @@ get_current_hotkey_name() {
     echo "SELECT Button (Button 12)"
   elif [ "$ra_hk" == "15" ]; then
     echo "R3 Button (Button 15)"
+  elif [ ! -z "$ra_hk" ]; then
+    echo "Button $ra_hk"
   else
-    echo "Custom (Button $ra_hk)"
+    echo "Not Set"
   fi
 }
 
 apply_hotkey() {
   local btn_id="$1"
   local btn_name="$2"
-  local ogage_code="$3"   # 0x2c4 for FN, 0x2c0 for SELECT, 0x2c3 for R3
+  local ogage_code="$3"   # e.g. 0x2c4, 0x2c0, 0x2c3
 
   dialog --infobox "\nSetting Hotkey to $btn_name...\nPlease wait..." 6 $width > /dev/tty1
 
@@ -79,12 +89,12 @@ apply_hotkey() {
   done
 
   # 3. Patch ogage binary for brightness modifier
-  if [ -f "/usr/local/bin/ogage" ]; then
+  if [ -f "/usr/local/bin/ogage" ] && [ ! -z "$ogage_code" ]; then
     python3 -c "
 import os, subprocess
 
 src = '/usr/local/bin/ogage'
-target_code = int('$ogage_code', 16) # e.g. 0x2c4, 0x2c0, 0x2c3
+target_code = int('$ogage_code', 16)
 
 with open(src, 'rb') as f:
     data = bytearray(f.read())
@@ -124,26 +134,113 @@ if count > 0:
   # 4. Restart EmulationStation
   sudo systemctl restart emulationstation > /dev/null 2>&1
 
-  dialog --msgbox "\nHotkey successfully changed to:\n$btn_name\n\n- In-game: $btn_name + X (Menu), $btn_name + START (Exit)\n- Brightness: $btn_name + VOL UP / DOWN" 10 $width > /dev/tty1
+  dialog --msgbox "\nHotkey successfully configured!\n\nNew Hotkey: $btn_name\nButton ID: $btn_id\n\n- In-game: $btn_name + X (Menu), $btn_name + START (Exit)\n- Brightness: $btn_name + VOL UP / DOWN" 12 $width > /dev/tty1
+}
+
+detect_interactive() {
+  # Stop gptokeyb so raw button press can be caught
+  stop_controls
+
+  dialog --infobox "\n--- Press Desired Hotkey Button ---\n\nPlease press the button on your console\nthat you want to use as the Hotkey\n(e.g. FN, SELECT, MENU, R3)...\n\nWaiting up to 15 seconds..." 10 $width > /dev/tty1
+
+  DETECT_JSON="/tmp/detected_hotkey.json"
+  rm -f "$DETECT_JSON"
+
+  python3 -c "
+import sys, os, time, select, json
+from evdev import InputDevice, list_devices, ecodes
+
+OUT_FILE = '$DETECT_JSON'
+
+def detect():
+    devs = []
+    for path in list_devices():
+        try:
+            d = InputDevice(path)
+            if ecodes.EV_KEY in d.capabilities():
+                devs.append(d)
+        except Exception:
+            pass
+    if not devs:
+        sys.exit(1)
+
+    dev_map = {d.fd: d for d in devs}
+    start = time.time()
+    while time.time() - start < 15:
+        r, _, _ = select.select(list(dev_map.keys()), [], [], 0.1)
+        for fd in r:
+            dev = dev_map[fd]
+            for ev in dev.read():
+                if ev.type == ecodes.EV_KEY and ev.value == 1:
+                    code = ev.code
+                    caps = dev.capabilities()
+                    keys = caps.get(ecodes.EV_KEY, [])
+                    btn_keys = [k for k in sorted(keys) if isinstance(k, int) and (k >= 0x100 or 'gamepad' in dev.name.lower() or 'joypad' in dev.name.lower())]
+                    btn_id = btn_keys.index(code) if code in btn_keys else code
+
+                    raw = ecodes.KEY.get(code, ecodes.BTN.get(code, f'KEY_{code}'))
+                    if isinstance(raw, (list, tuple)):
+                        raw = raw[0]
+
+                    if code == 708 or btn_id == 16:
+                        name = 'FN Button'
+                    elif code == 704 or btn_id == 12:
+                        name = 'SELECT Button'
+                    elif code == 705 or btn_id == 13:
+                        name = 'START Button'
+                    elif code == 707 or btn_id == 15:
+                        name = 'R3 Button (Right Stick Click)'
+                    elif code == 706 or btn_id == 14:
+                        name = 'L3 Button (Left Stick Click)'
+                    else:
+                        name = str(raw)
+
+                    res = {'button_id': str(btn_id), 'button_name': name, 'hex_code': hex(code), 'device': dev.name}
+                    with open(OUT_FILE, 'w') as f:
+                        json.dump(res, f)
+                    sys.exit(0)
+    sys.exit(2)
+detect()
+"
+  status=$?
+
+  # Restart controls for navigation
+  start_controls
+
+  if [ $status -ne 0 ] || [ ! -f "$DETECT_JSON" ]; then
+    dialog --msgbox "\nNo button press was detected (Timeout).\nPlease try again." 7 $width > /dev/tty1
+    return
+  fi
+
+  detected_id=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['button_id'])" 2>/dev/null)
+  detected_name=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['button_name'])" 2>/dev/null)
+  detected_hex=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['hex_code'])" 2>/dev/null)
+  detected_dev=$(python3 -c "import json; d=json.load(open('$DETECT_JSON')); print(d['device'])" 2>/dev/null)
+
+  dialog --yesno "\nDetected Button:\n  Name: $detected_name\n  Button ID: $detected_id\n  Linux Code: $detected_hex\n  Device: $detected_dev\n\nSet this button as your Global Hotkey?" 12 $width > /dev/tty1
+  if [ $? -eq 0 ]; then
+    apply_hotkey "$detected_id" "$detected_name" "$detected_hex"
+  fi
 }
 
 while true; do
   cur_hk=$(get_current_hotkey_name)
   
   options=(
-    1 "Set Hotkey to FN Button (Button 16 - R36S Default)"
-    2 "Set Hotkey to SELECT Button (Button 12 - ArkOS Classic)"
-    3 "Set Hotkey to R3 Button (Button 15 - Right Stick Click)"
-    4 "Exit"
+    1 "Press a button to set as Hotkey (Interactive Detect)"
+    2 "Set to FN Button (Button 16 - R36S Default)"
+    3 "Set to SELECT Button (Button 12 - ArkOS Classic)"
+    4 "Set to R3 Button (Button 15 - Right Stick Click)"
+    5 "Exit"
   )
 
   selection=(dialog \
-    --backtitle "dArkOS Global Hotkey Switcher" \
+    --backtitle "dArkOS Global Hotkey Manager" \
     --title "Current Hotkey: $cur_hk" \
     --no-collapse \
     --clear \
     --cancel-label "Exit" \
-    --menu "Select your desired Hotkey:" $height $width 15)
+    --menu "Select Hotkey Configuration:" $height $width 15)
 
   choice=$("${selection[@]}" "${options[@]}" 2>&1 > /dev/tty1)
   if [ $? -ne 0 ]; then
@@ -151,9 +248,10 @@ while true; do
   fi
 
   case $choice in
-    1) apply_hotkey "16" "FN Button (Button 16)" "0x2c4" ;;
-    2) apply_hotkey "12" "SELECT Button (Button 12)" "0x2c0" ;;
-    3) apply_hotkey "15" "R3 Button (Button 15)" "0x2c3" ;;
-    4) clean_exit ;;
+    1) detect_interactive ;;
+    2) apply_hotkey "16" "FN Button (Button 16)" "0x2c4" ;;
+    3) apply_hotkey "12" "SELECT Button (Button 12)" "0x2c0" ;;
+    4) apply_hotkey "15" "R3 Button (Button 15)" "0x2c3" ;;
+    5) clean_exit ;;
   esac
 done

--- a/finishing_touches-rk3566.sh
+++ b/finishing_touches-rk3566.sh
@@ -271,8 +271,11 @@ sudo cp scripts/arkos_ap_mode.sh Arkbuild/usr/local/bin/
 sudo cp scripts/auto_suspend* Arkbuild/usr/local/bin/
 sudo cp scripts/processcheck.sh Arkbuild/usr/local/bin/
 sudo cp scripts/autosuspend.service Arkbuild/etc/systemd/system/
+sudo cp scripts/lowbatt_suspend.sh Arkbuild/usr/local/bin/
+sudo cp scripts/lowbatt-suspend.service Arkbuild/etc/systemd/system/
 sudo chroot Arkbuild/ bash -c "pip install --break-system-packages --root-user-action ignore inputs"
 sudo chroot Arkbuild/ bash -c "systemctl disable autosuspend"
+sudo chroot Arkbuild/ bash -c "systemctl enable lowbatt-suspend"
 sudo cp scripts/rk3566/shutdowntasks.service Arkbuild/etc/systemd/system/
 sudo chroot Arkbuild/ bash -c "(crontab -l 2>/dev/null; echo \"@reboot /usr/local/bin/panel_set.sh RestoreSettings &\") | crontab -"
 sudo chroot Arkbuild/ bash -c "systemctl enable shutdowntasks"

--- a/finishing_touches.sh
+++ b/finishing_touches.sh
@@ -209,8 +209,11 @@ sudo cp scripts/arkos_ap_mode.sh Arkbuild/usr/local/bin/
 sudo cp scripts/auto_suspend* Arkbuild/usr/local/bin/
 sudo cp scripts/processcheck.sh Arkbuild/usr/local/bin/
 sudo cp scripts/autosuspend.service Arkbuild/etc/systemd/system/
+sudo cp scripts/lowbatt_suspend.sh Arkbuild/usr/local/bin/
+sudo cp scripts/lowbatt-suspend.service Arkbuild/etc/systemd/system/
 sudo chroot Arkbuild/ bash -c "pip install --break-system-packages --root-user-action ignore inputs"
 sudo chroot Arkbuild/ bash -c "systemctl disable autosuspend"
+sudo chroot Arkbuild/ bash -c "systemctl enable lowbatt-suspend"
 sudo cp scripts/wifi_importer.service Arkbuild/etc/systemd/system/
 sudo chroot Arkbuild/ bash -c "systemctl enable wifi_importer"
 sudo cp scripts/keystroke.py Arkbuild/usr/local/bin/

--- a/scripts/detect_hotkey.py
+++ b/scripts/detect_hotkey.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import sys, os, time, select, json
+from evdev import InputDevice, list_devices, ecodes
+
+OUT_FILE = "/tmp/detected_hotkey.json"
+
+def get_gamepad_devices():
+    devs = []
+    for path in list_devices():
+        try:
+            dev = InputDevice(path)
+            caps = dev.capabilities()
+            if ecodes.EV_KEY in caps:
+                devs.append(dev)
+        except Exception:
+            pass
+    return devs
+
+def detect_button(timeout_sec=15):
+    devices = get_gamepad_devices()
+    if not devices:
+        print("ERROR: No input devices found.")
+        sys.exit(1)
+
+    dev_map = {dev.fd: dev for dev in devices}
+    start_time = time.time()
+
+    while time.time() - start_time < timeout_sec:
+        r, _, _ = select.select(list(dev_map.keys()), [], [], 0.2)
+        for fd in r:
+            dev = dev_map[fd]
+            for event in dev.read():
+                if event.type == ecodes.EV_KEY and event.value == 1: # Key press
+                    code = event.code
+                    caps = dev.capabilities()
+                    keys = caps.get(ecodes.EV_KEY, [])
+                    btn_keys = [k for k in sorted(keys) if isinstance(k, int) and (k >= 0x100 or 'gamepad' in dev.name.lower() or 'joypad' in dev.name.lower())]
+                    
+                    if code in btn_keys:
+                        btn_id = btn_keys.index(code)
+                    else:
+                        btn_id = code # fallback
+
+                    raw_name = ecodes.KEY.get(code, ecodes.BTN.get(code, f"CODE_{code}"))
+                    if isinstance(raw_name, (list, tuple)):
+                        raw_name = raw_name[0]
+
+                    # User-friendly label
+                    if code == 708 or btn_id == 16:
+                        display_name = f"FN Button (ID: {btn_id})"
+                    elif code == 704 or btn_id == 12:
+                        display_name = f"SELECT Button (ID: {btn_id})"
+                    elif code == 705 or btn_id == 13:
+                        display_name = f"START Button (ID: {btn_id})"
+                    elif code == 707 or btn_id == 15:
+                        display_name = f"R3 Button (Right Stick Click, ID: {btn_id})"
+                    elif code == 706 or btn_id == 14:
+                        display_name = f"L3 Button (Left Stick Click, ID: {btn_id})"
+                    else:
+                        display_name = f"{raw_name} (ID: {btn_id})"
+
+                    result = {
+                        "device_name": dev.name,
+                        "device_path": dev.path,
+                        "keycode": code,
+                        "hex_code": f"0x{code:x}",
+                        "button_id": btn_id,
+                        "button_name": display_name,
+                        "raw_name": str(raw_name)
+                    }
+
+                    with open(OUT_FILE, 'w', encoding='utf-8') as f:
+                        json.dump(result, f, indent=2)
+
+                    print(f"SUCCESS: Captured {display_name} on {dev.name}")
+                    return result
+
+    print("TIMEOUT: No button pressed within time limit.")
+    sys.exit(2)
+
+if __name__ == '__main__':
+    detect_button(15)

--- a/scripts/keystroke.py
+++ b/scripts/keystroke.py
@@ -1,8 +1,40 @@
 #!/usr/bin/env python3
-from evdev import uinput, ecodes as e
-import time
+import os, struct, fcntl, time
 
-with uinput.UInput() as ui:
-    ui.write(e.EV_KEY, e.KEY_LEFTSHIFT, 1)
-    time.sleep(0.11)
-    ui.syn()
+UI_SET_EVBIT = 0x40045564
+UI_SET_KEYBIT = 0x40045565
+UI_DEV_CREATE = 0x5501
+UI_DEV_DESTROY = 0x5502
+
+EV_SYN = 0
+EV_KEY = 1
+KEY_LEFTSHIFT = 42
+SYN_REPORT = 0
+
+def send_shift():
+    try:
+        fd = os.open('/dev/uinput', os.O_WRONLY | os.O_NONBLOCK)
+    except Exception:
+        return
+    try:
+        fcntl.ioctl(fd, UI_SET_EVBIT, EV_KEY)
+        fcntl.ioctl(fd, UI_SET_KEYBIT, KEY_LEFTSHIFT)
+        uinput_user_dev = struct.pack('80sHHHH1028s', b'virtual-keyboard', 0x03, 0x01, 0x01, 0x01, b'\x00' * 1028)
+        os.write(fd, uinput_user_dev)
+        fcntl.ioctl(fd, UI_DEV_CREATE)
+        time.sleep(0.05)
+        event_press = struct.pack('qqHHi', 0, 0, EV_KEY, KEY_LEFTSHIFT, 1)
+        event_syn = struct.pack('qqHHi', 0, 0, EV_SYN, SYN_REPORT, 0)
+        event_release = struct.pack('qqHHi', 0, 0, EV_KEY, KEY_LEFTSHIFT, 0)
+        os.write(fd, event_press)
+        os.write(fd, event_syn)
+        time.sleep(0.05)
+        os.write(fd, event_release)
+        os.write(fd, event_syn)
+        time.sleep(0.05)
+        fcntl.ioctl(fd, UI_DEV_DESTROY)
+    finally:
+        os.close(fd)
+
+if __name__ == '__main__':
+    send_shift()

--- a/scripts/lowbatt-suspend.service
+++ b/scripts/lowbatt-suspend.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Suspend on low battery
+After=multi-user.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/lowbatt_suspend.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/lowbatt_suspend.sh
+++ b/scripts/lowbatt_suspend.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Suspend console when battery drops below threshold and not charging.
+CONF=/home/ark/.config/.LOWBATT
+CAP=/sys/class/power_supply/battery/capacity
+INTERVAL=30
+NEEDED=3
+
+low_count=0
+
+read_threshold() {
+  local t
+  t=$(cat "$CONF" 2>/dev/null | tr -dc '0-9')
+  [ -z "$t" ] && t=5
+  [ "$t" -lt 1 ] && t=1
+  [ "$t" -gt 50 ] && t=50
+  echo "$t"
+}
+
+is_charging() {
+  grep -qi "charging" /sys/class/power_supply/*/status 2>/dev/null || \
+  grep -q "1" /sys/class/power_supply/*/online 2>/dev/null
+}
+
+while true; do
+  sleep "$INTERVAL"
+  [ -r "$CAP" ] || continue
+
+  cap=$(cat "$CAP" 2>/dev/null | tr -dc '0-9')
+  [ -z "$cap" ] && continue
+
+  if is_charging; then
+    low_count=0
+    continue
+  fi
+
+  thr=$(read_threshold)
+  if [ "$cap" -le "$thr" ]; then
+    low_count=$((low_count+1))
+    logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
+    if [ "$low_count" -ge "$NEEDED" ]; then
+      logger -t lowbatt "suspending console at ${cap}% battery"
+      sync
+      /bin/systemctl suspend
+      low_count=0
+      sleep 120
+    fi
+  else
+    low_count=0
+  fi
+done

--- a/scripts/lowbatt_suspend.sh
+++ b/scripts/lowbatt_suspend.sh
@@ -39,9 +39,8 @@ while true; do
     logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
     if [ "$low_count" -ge "$NEEDED" ]; then
       logger -t lowbatt "suspending console at ${cap}% battery"
-      # Voice warning announcement
-      /usr/local/bin/speak_bat_life.sh critical_suspend >/dev/null 2>&1 &
-      sleep 4
+      # Play voice warning and suspend immediately when finished
+      /usr/local/bin/speak_bat_life.sh critical_suspend
       sync
       /bin/systemctl suspend
       low_count=0

--- a/scripts/lowbatt_suspend.sh
+++ b/scripts/lowbatt_suspend.sh
@@ -39,6 +39,9 @@ while true; do
     logger -t lowbatt "battery ${cap}%, threshold ${thr}%, count ${low_count}/${NEEDED}"
     if [ "$low_count" -ge "$NEEDED" ]; then
       logger -t lowbatt "suspending console at ${cap}% battery"
+      # Voice warning announcement
+      /usr/local/bin/speak_bat_life.sh critical_suspend >/dev/null 2>&1 &
+      sleep 4
       sync
       /bin/systemctl suspend
       low_count=0

--- a/scripts/speak_bat_life.sh
+++ b/scripts/speak_bat_life.sh
@@ -3,23 +3,121 @@ export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
 . /usr/local/bin/buttonmon.sh 2>/dev/null
 
+# Detect language from EmulationStation configuration or system
+get_language() {
+  local lang
+  if [ -f "/home/ark/.emulationstation/es_settings.cfg" ]; then
+    lang=$(grep '<string name="Language"' /home/ark/.emulationstation/es_settings.cfg 2>/dev/null | sed -n 's/.*value="\([^"]*\)".*/\1/p' | tr '[:upper:]' '[:lower:]')
+  fi
+  if [ -z "$lang" ] && [ -f "/home/ark/.config/.LANGUAGE" ]; then
+    lang=$(cat /home/ark/.config/.LANGUAGE 2>/dev/null | tr -dc 'a-zA-Z_' | tr '[:upper:]' '[:lower:]')
+  fi
+  if [ -z "$lang" ]; then
+    lang="${LANG:0:2}"
+  fi
+  [ -z "$lang" ] && lang="en"
+  echo "${lang:0:2}"
+}
+
+LANG_CODE=$(get_language)
+
+# Select voice based on MBROLA config or language
 if [ -e "/home/ark/.config/.MBROLA_VOICE_FEMALE" ]; then
-  voice="1"
+  mb_voice="1"
 elif [ -e "/home/ark/.config/.MBROLA_VOICE_MALE3" ]; then
-  voice="3"
+  mb_voice="3"
 else
-  voice="2"
+  mb_voice="2"
 fi
 
-speak() {
-  local msg="$1"
+speak_text() {
+  local voice_param="$1"
+  local text="$2"
+
   if [ "$(id -u)" -eq 0 ] && command -v runuser >/dev/null 2>&1; then
-    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "$msg" 2>/dev/null || espeak-ng -s130 "$msg" 2>/dev/null
+    runuser -u ark -- espeak-ng $voice_param -s130 "$text" 2>/dev/null || espeak-ng -s130 "$text" 2>/dev/null
   else
-    espeak-ng -vmb-us${voice} -s130 "$msg" 2>/dev/null || espeak-ng -s130 "$msg" 2>/dev/null
+    espeak-ng $voice_param -s130 "$text" 2>/dev/null || espeak-ng -s130 "$text" 2>/dev/null
   fi
 }
 
+speak_i18n() {
+  local type="$1"   # "battery" or "governor" or "cpu_speed"
+  local val="$2"
+
+  local voice_arg=""
+  local msg=""
+
+  case "$LANG_CODE" in
+    pl)
+      voice_arg="-vpl"
+      case "$type" in
+        battery)   msg="Poziom baterii wynosi $val procent" ;;
+        governor)  msg="Aktualny profil zasilania to $val" ;;
+        cpu_speed) msg="Taktowanie procesora wynosi $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    es)
+      voice_arg="-ves"
+      case "$type" in
+        battery)   msg="El nivel de batería es del $val por ciento" ;;
+        governor)  msg="El perfil de rendimiento actual es $val" ;;
+        cpu_speed) msg="La velocidad de la CPU es $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    fr)
+      voice_arg="-vfr"
+      case "$type" in
+        battery)   msg="Le niveau de batterie est à $val pour cent" ;;
+        governor)  msg="Le profil de performance actuel est $val" ;;
+        cpu_speed) msg="La vitesse du processeur est de $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    de)
+      voice_arg="-vde"
+      case "$type" in
+        battery)   msg="Der Akkustand beträgt $val Prozent" ;;
+        governor)  msg="Das aktuelle Leistungsprofil ist $val" ;;
+        cpu_speed) msg="Die CPU Geschwindigkeit beträgt $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    it)
+      voice_arg="-vit"
+      case "$type" in
+        battery)   msg="Il livello della batteria è al $val per cento" ;;
+        governor)  msg="Il profilo delle prestazioni è $val" ;;
+        cpu_speed) msg="La velocità della CPU è $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    pt)
+      voice_arg="-vpt"
+      case "$type" in
+        battery)   msg="O nível da bateria está em $val por cento" ;;
+        governor)  msg="O perfil de desempenho atual é $val" ;;
+        cpu_speed) msg="A velocidade da CPU é $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+    *)
+      voice_arg="-vmb-us${mb_voice}"
+      case "$type" in
+        battery)   msg="Your battery level is at $val percent" ;;
+        governor)  msg="The current performance governor is $val" ;;
+        cpu_speed) msg="CPU speed is currently $val" ;;
+        custom)    msg="$val" ;;
+      esac
+      ;;
+  esac
+
+  speak_text "$voice_arg" "$msg"
+}
+
+# Check trigger buttons
 if [ -f "/boot/rk3326-rg351v-linux.dtb" ] || [ -f "/boot/rk3326-gameforce-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux-v11.dtb" ]; then
   Test_Button_R1 2>/dev/null
 else
@@ -27,9 +125,11 @@ else
 fi
 
 if [ "$?" -eq "10" ] && [[ -z "$@" ]]; then
-  speak "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)"
-  if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null) == "userspace" ]]; then
-    speak "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)" &
+  gov=$(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)
+  speak_i18n "governor" "$gov"
+  if [[ "$gov" == "userspace" ]]; then
+    freq_str=$(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)
+    speak_i18n "cpu_speed" "$freq_str" &
   fi
 else
   if [[ -f /tmp/battery.percent ]]; then
@@ -41,16 +141,18 @@ else
   [ -z "$bat_val" ] && bat_val="unknown"
 
   if [[ ! -z "$@" ]]; then
-    speak "${@} $bat_val percent"
+    speak_i18n "custom" "${@} $bat_val"
   else
-    speak "Your battery level is at $bat_val percent"
+    speak_i18n "battery" "$bat_val"
   fi
 
   Test_Button_R2 2>/dev/null
   if [ "$?" -eq "10" ]; then
-    speak "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)"
-    if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null) == "userspace" ]]; then
-      speak "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)" &
+    gov=$(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)
+    speak_i18n "governor" "$gov"
+    if [[ "$gov" == "userspace" ]]; then
+      freq_str=$(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)
+      speak_i18n "cpu_speed" "$freq_str" &
     fi
   fi
 fi

--- a/scripts/speak_bat_life.sh
+++ b/scripts/speak_bat_life.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 
-. /usr/local/bin/buttonmon.sh
+. /usr/local/bin/buttonmon.sh 2>/dev/null
 
 if [ -e "/home/ark/.config/.MBROLA_VOICE_FEMALE" ]; then
   voice="1"
@@ -10,16 +11,25 @@ else
   voice="2"
 fi
 
+speak() {
+  local msg="$1"
+  if [ "$(id -u)" -eq 0 ] && command -v runuser >/dev/null 2>&1; then
+    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "$msg" 2>/dev/null || espeak-ng -s130 "$msg" 2>/dev/null
+  else
+    espeak-ng -vmb-us${voice} -s130 "$msg" 2>/dev/null || espeak-ng -s130 "$msg" 2>/dev/null
+  fi
+}
+
 if [ -f "/boot/rk3326-rg351v-linux.dtb" ] || [ -f "/boot/rk3326-gameforce-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux-v11.dtb" ]; then
-  Test_Button_R1
+  Test_Button_R1 2>/dev/null
 else
-  Test_Button_R2
+  Test_Button_R2 2>/dev/null
 fi
+
 if [ "$?" -eq "10" ] && [[ -z "$@" ]]; then
-  echo $(ps -o comm= -p $PPID)
-  runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor)"
-  if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor) == "userspace" ]]; then
-    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq)" &
+  speak "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)"
+  if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null) == "userspace" ]]; then
+    speak "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)" &
   fi
 else
   if [[ -f /tmp/battery.percent ]]; then
@@ -27,17 +37,20 @@ else
   else
     BAT_FILE="/sys/class/power_supply/battery/capacity"
   fi
+  bat_val=$(cat "$BAT_FILE" 2>/dev/null | tr -dc '0-9')
+  [ -z "$bat_val" ] && bat_val="unknown"
+
   if [[ ! -z "$@" ]]; then
-    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "${@} $(cat $BAT_FILE) percent"
+    speak "${@} $bat_val percent"
   else
-    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "Your battery level is at $(cat $BAT_FILE) percent"
+    speak "Your battery level is at $bat_val percent"
   fi
 
-  Test_Button_R2
+  Test_Button_R2 2>/dev/null
   if [ "$?" -eq "10" ]; then
-    runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor)"
-    if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor) == "userspace" ]]; then
-      runuser -u ark -- espeak-ng -vmb-us${voice} -s130 "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq)" &
+    speak "The current performance governor is $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null)"
+    if [[ $(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor 2>/dev/null) == "userspace" ]]; then
+      speak "CPU speed is currently $(awk 'length==6{printf("%.0f MHz\n", $0/10^3); next} length==7{printf("%.1f GHz\n", $0/10^6)}' /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq 2>/dev/null)" &
     fi
   fi
 fi

--- a/scripts/speak_bat_life.sh
+++ b/scripts/speak_bat_life.sh
@@ -42,7 +42,7 @@ speak_text() {
 }
 
 speak_i18n() {
-  local type="$1"   # "battery" or "governor" or "cpu_speed"
+  local type="$1"   # "battery", "governor", "cpu_speed", "critical_suspend", "custom"
   local val="$2"
 
   local voice_arg=""
@@ -52,70 +52,83 @@ speak_i18n() {
     pl)
       voice_arg="-vpl"
       case "$type" in
-        battery)   msg="Poziom baterii wynosi $val procent" ;;
-        governor)  msg="Aktualny profil zasilania to $val" ;;
-        cpu_speed) msg="Taktowanie procesora wynosi $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="Poziom baterii wynosi $val procent" ;;
+        governor)         msg="Aktualny profil zasilania to $val" ;;
+        cpu_speed)        msg="Taktowanie procesora wynosi $val" ;;
+        critical_suspend) msg="Krytyczny poziom baterii. Nastepuje uspienie konsoli." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     es)
       voice_arg="-ves"
       case "$type" in
-        battery)   msg="El nivel de batería es del $val por ciento" ;;
-        governor)  msg="El perfil de rendimiento actual es $val" ;;
-        cpu_speed) msg="La velocidad de la CPU es $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="El nivel de batería es del $val por ciento" ;;
+        governor)         msg="El perfil de rendimiento actual es $val" ;;
+        cpu_speed)        msg="La velocidad de la CPU es $val" ;;
+        critical_suspend) msg="Nivel crítico de batería. Suspendiendo la consola." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     fr)
       voice_arg="-vfr"
       case "$type" in
-        battery)   msg="Le niveau de batterie est à $val pour cent" ;;
-        governor)  msg="Le profil de performance actuel est $val" ;;
-        cpu_speed) msg="La vitesse du processeur est de $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="Le niveau de batterie est à $val pour cent" ;;
+        governor)         msg="Le profil de performance actuel est $val" ;;
+        cpu_speed)        msg="La vitesse du processeur est de $val" ;;
+        critical_suspend) msg="Niveau de batterie critique. Mise en veille de la console." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     de)
       voice_arg="-vde"
       case "$type" in
-        battery)   msg="Der Akkustand beträgt $val Prozent" ;;
-        governor)  msg="Das aktuelle Leistungsprofil ist $val" ;;
-        cpu_speed) msg="Die CPU Geschwindigkeit beträgt $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="Der Akkustand beträgt $val Prozent" ;;
+        governor)         msg="Das aktuelle Leistungsprofil ist $val" ;;
+        cpu_speed)        msg="Die CPU Geschwindigkeit beträgt $val" ;;
+        critical_suspend) msg="Kritischer Batteriestand. Konsole wird in den Ruhezustand versetzt." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     it)
       voice_arg="-vit"
       case "$type" in
-        battery)   msg="Il livello della batteria è al $val per cento" ;;
-        governor)  msg="Il profilo delle prestazioni è $val" ;;
-        cpu_speed) msg="La velocità della CPU è $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="Il livello della batteria è al $val per cento" ;;
+        governor)         msg="Il profilo delle prestazioni è $val" ;;
+        cpu_speed)        msg="La velocità della CPU è $val" ;;
+        critical_suspend) msg="Livello di batteria critico. Sospensione della console." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     pt)
       voice_arg="-vpt"
       case "$type" in
-        battery)   msg="O nível da bateria está em $val por cento" ;;
-        governor)  msg="O perfil de desempenho atual é $val" ;;
-        cpu_speed) msg="A velocidade da CPU é $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="O nível da bateria está em $val por cento" ;;
+        governor)         msg="O perfil de desempenho atual é $val" ;;
+        cpu_speed)        msg="A velocidade da CPU é $val" ;;
+        critical_suspend) msg="Nível crítico de bateria. Suspendendo o console." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
     *)
       voice_arg="-vmb-us${mb_voice}"
       case "$type" in
-        battery)   msg="Your battery level is at $val percent" ;;
-        governor)  msg="The current performance governor is $val" ;;
-        cpu_speed) msg="CPU speed is currently $val" ;;
-        custom)    msg="$val" ;;
+        battery)          msg="Your battery level is at $val percent" ;;
+        governor)         msg="The current performance governor is $val" ;;
+        cpu_speed)        msg="CPU speed is currently $val" ;;
+        critical_suspend) msg="Critical battery level. Suspending console now." ;;
+        custom)           msg="$val" ;;
       esac
       ;;
   esac
 
   speak_text "$voice_arg" "$msg"
 }
+
+# Check special argument
+if [[ "$1" == "critical_suspend" ]]; then
+  speak_i18n "critical_suspend" ""
+  exit 0
+fi
 
 # Check trigger buttons
 if [ -f "/boot/rk3326-rg351v-linux.dtb" ] || [ -f "/boot/rk3326-gameforce-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux.dtb" ] || [ -f "/boot/rk3326-odroidgo2-linux-v11.dtb" ]; then


### PR DESCRIPTION
## Summary of Changes

This Pull Request introduces three key enhancements to dArkOS:

### 1. Interactive Global Hotkey Switcher (`dArkOS_Tools/Advanced/Switch Global Hotkey.sh` & `scripts/detect_hotkey.py`)
- **Interactive Button Detection**: Allows users to press any button on their handheld (FN, SELECT, MENU, R3, etc.) to automatically detect its Linux keycode and compute its exact SDL / RetroArch button ID on the fly.
- **Quick Presets**: Also includes direct presets for common setups (FN Button / Button 16 on R36S/R35S, SELECT Button / Button 12 on standard ArkOS layouts, and R3 Button / Button 15).
- **Automated Configuration**: Upon selecting a hotkey, the tool automatically updates:
  - RetroArch & RetroArch32 configs (`input_enable_hotkey_btn`)
  - EmulationStation input mappings (`system_hk`, `hotkeyenable`, `hotkey`)
  - The `ogage` binary brightness modifier instruction on the fly
  - Restarts `ogage.service` and `emulationstation.service`

### 2. Low Battery Auto-Suspend Protection (`scripts/lowbatt_suspend.sh`, `scripts/lowbatt-suspend.service`, `dArkOS_Tools/Advanced/Low Battery Suspend.sh`)
- **Background Daemon & Systemd Unit**: Safely suspends the handheld (`sync; systemctl suspend`) when battery capacity drops below a configurable threshold (default: 5%) when not connected to AC / USB charger.
- **Noise / Voltage Spike Filter**: Requires 3 consecutive low readings (90 seconds) to prevent false triggers under momentary high SoC load.
- **Universal Charger Detection**: Checks `/sys/class/power_supply/*/status` and `online` flags across RK3326/RK3566 architectures.
- **Interactive Management Tool**: Adds a GUI dialog tool under **Options -> Advanced -> Low Battery Suspend** to toggle the daemon, adjust threshold (5%, 10%, 15%), or test instant suspend.
- **Build Integration**: Integrated into `finishing_touches.sh` and `finishing_touches-rk3566.sh` for new rootfs builds.

### 3. Linux 4.4 Kernel uinput Compatibility (`scripts/keystroke.py`)
- Replaces high-level `uinput.UInput()` setup with kernel 4.4 compatible raw `ioctl` struct packing (`uinput_user_dev`), resolving `OSError: [Errno 22] Invalid argument` on Linux 4.4 during suspend/wake keystroke emulation.

---

### Testing & Verification
- Tested and verified on R36S (RK3326 Linux 4.4.189).
- Verified seamless auto-suspend and resume during active PortMaster game execution and EmulationStation navigation.
- Verified interactive hotkey detection and brightness combination adjustments.
