### PR TITLE
Fix make clean loop device cleanup to tighten match and avoid infinite retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ clean:
 	[ -f "wget-log" ] && sudo rm -f wget-log* || true
 	source utils.sh && remove_arkbuild && remove_arkbuild32
 	sudo rm -rf Arkbuild Arkbuild32 Arkbuild-final arkos_* main mnt odroidgoA-4.4.y ArkOS_* rg351 wget-*
-	while losetup -a | grep -m 1 ArkOS; do sudo losetup -d "$$(losetup -a | grep ArkOS | cut -d ':' -f 1)"; done
+	for devlo in $$(losetup -a | grep -F "($$(pwd)/" | cut -d ':' -f 1); do sudo losetup -d "$$devlo" || echo "Skipping $$devlo (still in use)"; done
 	@echo "Done!"
 
 clean_devenv:


### PR DESCRIPTION
make clean used to scan every loop device on the system for "ArkOS" in the path and retry forever on anything busy. That could hang the build and grab loop devices that didn't belong to the make process.

Now it only touches loop devices backed by files inside the build directory, and tries each one once. A busy device gets skipped with a message instead of hanging.

Tested by hand with three loop devices: one mounted inside the build dir, one free inside the build dir, one outside it. The mounted one stayed untouched, the free one got detached, the outside one was never touched.